### PR TITLE
[Feature] 개인화 설정

### DIFF
--- a/src/main/java/goorm/ddok/member/controller/AuthController.java
+++ b/src/main/java/goorm/ddok/member/controller/AuthController.java
@@ -1,6 +1,5 @@
 package goorm.ddok.member.controller;
 
-
 import goorm.ddok.global.response.ApiResponseDto;
 import goorm.ddok.global.security.auth.CustomUserDetails;
 import goorm.ddok.global.util.sentry.SentryUserContextService;
@@ -13,6 +12,14 @@ import goorm.ddok.member.service.TokenService;
 import io.sentry.Sentry;
 import io.sentry.SentryLevel;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletResponse;
@@ -35,126 +42,334 @@ public class AuthController {
     private final SentryUserContextService sentryUserContextService;
     private final EmailVerificationService emailVerificationService;
 
-
-    @Operation(summary = "회원가입")
+    @Operation(
+            summary = "회원가입",
+            description = "사용자 회원가입을 수행합니다. 이메일 인증 메일이 발송됩니다.",
+            requestBody = @RequestBody(
+                    required = true,
+                    content = @Content(
+                            schema = @Schema(implementation = SignUpRequest.class),
+                            examples = @ExampleObject(name = "요청 예시", value = """
+                {
+                  "email": "test@test.com",
+                  "username": "홍길동",
+                  "password": "1Q2w3e4r!@#",
+                  "passwordCheck": "1Q2w3e4r!@#",
+                  "phoneNumber": "01012345678",
+                  "phoneCode": "828282"
+                }
+                """)
+                    )
+            )
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "회원가입 성공",
+                    content = @Content(schema = @Schema(implementation = ApiResponseDto.class),
+                            examples = @ExampleObject(value = """
+                { "status": 201, "message": "회원가입이 완료되었습니다.", "data": { "id": 1, "username": "홍길동" } }
+                """))),
+            @ApiResponse(responseCode = "400", description = "입력값 오류 (이름/비밀번호/전화번호 형식 등)",
+                    content = @Content(schema = @Schema(implementation = ApiResponseDto.class),
+                            examples = @ExampleObject(value = """
+                { "status": 400, "message": "비밀번호는 8자 이상이어야 합니다.", "data": null }
+                """))),
+            @ApiResponse(responseCode = "409", description = "중복 이메일/전화번호",
+                    content = @Content(schema = @Schema(implementation = ApiResponseDto.class),
+                            examples = @ExampleObject(value = """
+                { "status": 409, "message": "이미 가입된 이메일입니다.", "data": null }
+                """))),
+            @ApiResponse(responseCode = "500", description = "서버 오류",
+                    content = @Content(schema = @Schema(implementation = ApiResponseDto.class)))
+    })
     @PostMapping("/signup")
     public ResponseEntity<ApiResponseDto<SignUpResponse>> signUp(@Valid @RequestBody SignUpRequest signUpRequest) {
         SignUpResponse response = authService.signup(signUpRequest);
         return ResponseEntity.ok(ApiResponseDto.of(201, "회원가입이 완료되었습니다.", response));
     }
 
-    @Operation(summary = "이메일 중복 확인")
+    @Operation(
+            summary = "이메일 중복 확인",
+            description = "입력한 이메일로 가입 가능 여부를 확인합니다.",
+            requestBody = @RequestBody(
+                    required = true,
+                    content = @Content(
+                            schema = @Schema(implementation = EmailCheckRequest.class),
+                            examples = @ExampleObject(value = """
+                { "email": "test@test.com" }
+                """)
+                    )
+            )
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "사용 가능한 이메일",
+                    content = @Content(schema = @Schema(implementation = ApiResponseDto.class),
+                            examples = @ExampleObject(value = """
+                { "status": 200, "message": "사용 가능한 이메일입니다.", "data": { "IsAvailable": true } }
+                """))),
+            @ApiResponse(responseCode = "409", description = "중복 이메일",
+                    content = @Content(schema = @Schema(implementation = ApiResponseDto.class),
+                            examples = @ExampleObject(value = """
+                { "status": 409, "message": "이미 가입된 이메일입니다.", "data": null }
+                """)))
+    })
     @PostMapping("/email/check")
     public ResponseEntity<ApiResponseDto<EmailCheckResponse>> checkEmail(
             @Valid @RequestBody EmailCheckRequest emailCheckRequest) {
         boolean isAvailable = authService.isEmailAlreadyExist(emailCheckRequest.getEmail());
-
         EmailCheckResponse emailCheckResponse = new EmailCheckResponse(isAvailable);
-
-        return ResponseEntity.ok(ApiResponseDto.of(
-                200, "사용 가능한 이메일입니다.", emailCheckResponse
-        ));
+        return ResponseEntity.ok(ApiResponseDto.of(200, "사용 가능한 이메일입니다.", emailCheckResponse));
     }
 
     @Operation(
-            summary = "전화번호 인증"
+            summary = "전화번호 인증 코드 발송",
+            description = "입력한 전화번호로 6자리 인증번호를 발송합니다. (유효시간 초 단위 반환)",
+            requestBody = @RequestBody(
+                    required = true,
+                    content = @Content(
+                            schema = @Schema(implementation = PhoneVerificationRequest.class),
+                            examples = @ExampleObject(value = """
+                { "phoneNumber": "01012345678", "username": "홍길동", "authType": "SIGN_UP" }
+                """)
+                    )
+            )
     )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "발송 성공",
+                    content = @Content(schema = @Schema(implementation = ApiResponseDto.class),
+                            examples = @ExampleObject(value = """
+                { "status": 200, "message": "인증번호가 발송되었습니다.", "data": { "expiresIn": 60 } }
+                """))),
+            @ApiResponse(responseCode = "400", description = "전화번호 형식 오류",
+                    content = @Content(schema = @Schema(implementation = ApiResponseDto.class),
+                            examples = @ExampleObject(value = """
+                { "status": 400, "message": "올바른 휴대전화 번호 형식이 아닙니다.", "data": null }
+                """))),
+            @ApiResponse(responseCode = "409", description = "중복 이름+전화번호 (회원가입 중)",
+                    content = @Content(schema = @Schema(implementation = ApiResponseDto.class),
+                            examples = @ExampleObject(value = """
+                { "status": 409, "message": "해당 이름과 연락처로 이미 가입된 회원이 있습니다.", "data": null }
+                """))),
+            @ApiResponse(responseCode = "500", description = "SMS 발송 실패",
+                    content = @Content(schema = @Schema(implementation = ApiResponseDto.class),
+                            examples = @ExampleObject(value = """
+                { "status": 500, "message": "SMS 발송 실패", "data": null }
+                """)))
+    })
     @PostMapping("/phone/send-code")
     public ResponseEntity<ApiResponseDto<PhoneVerificationResponse>> sendCode(
             @Valid @RequestBody PhoneVerificationRequest request) {
-
         int time = phoneVerificationService.sendVerificationCode(
-                request.getPhoneNumber(),
-                request.getUsername(),
-                request.getAuthType()
-        );
-
+                request.getPhoneNumber(), request.getUsername(), request.getAuthType());
         PhoneVerificationResponse expiresIn = new PhoneVerificationResponse(time);
-
         return ResponseEntity.ok(ApiResponseDto.of(200, "인증번호가 발송되었습니다.", expiresIn));
     }
 
     @Operation(
-            summary = "전화번호 인증번호 확인"
+            summary = "전화번호 인증번호 확인",
+            description = "수신한 인증번호를 검증합니다.",
+            requestBody = @RequestBody(
+                    required = true,
+                    content = @Content(
+                            schema = @Schema(implementation = PhoneVerifyCodeRequest.class),
+                            examples = @ExampleObject(value = """
+                { "phoneNumber": "01012345678", "phoneCode": "123456" }
+                """)
+                    )
+            )
     )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "인증 성공",
+                    content = @Content(schema = @Schema(implementation = ApiResponseDto.class),
+                            examples = @ExampleObject(value = """
+                { "status": 200, "message": "인증에 성공했습니다.", "data": { "verified": true } }
+                """))),
+            @ApiResponse(responseCode = "400", description = "인증번호 만료",
+                    content = @Content(schema = @Schema(implementation = ApiResponseDto.class),
+                            examples = @ExampleObject(value = """
+                { "status": 400, "message": "인증번호가 만료되었습니다.", "data": null }
+                """))),
+            @ApiResponse(responseCode = "404", description = "인증 요청 기록 없음",
+                    content = @Content(schema = @Schema(implementation = ApiResponseDto.class),
+                            examples = @ExampleObject(value = """
+                { "status": 404, "message": "인증 요청 기록이 없습니다.", "data": null }
+                """))),
+            @ApiResponse(responseCode = "409", description = "이미 인증 완료된 요청",
+                    content = @Content(schema = @Schema(implementation = ApiResponseDto.class),
+                            examples = @ExampleObject(value = """
+                { "status": 409, "message": "이미 인증이 완료된 계정입니다.", "data": null }
+                """)))
+    })
     @PostMapping("/phone/verify-code")
     public ResponseEntity<ApiResponseDto<PhoneVerifyCodeResponse>> verifyCode(
             @Valid @RequestBody PhoneVerifyCodeRequest request) {
-
         boolean verificationResult = phoneVerificationService.verifyCode(request.getPhoneNumber(), request.getPhoneCode());
-
         PhoneVerifyCodeResponse verificationResponse = new PhoneVerifyCodeResponse(verificationResult);
-
         return ResponseEntity.ok(ApiResponseDto.of(200, "인증에 성공했습니다.", verificationResponse));
     }
 
     @Operation(
-            summary = "이메일 인증"
+            summary = "이메일 인증 처리(리다이렉트)",
+            description = "이메일로 전달된 인증 링크를 통해 인증을 완료합니다. 완료 후 프론트엔드로 리다이렉트됩니다."
     )
+    @ApiResponses({
+            @ApiResponse(responseCode = "302", description = "리다이렉트 성공 (프론트 페이지로 이동)"),
+            @ApiResponse(responseCode = "400", description = "잘못되었거나 만료된 코드",
+                    content = @Content(schema = @Schema(implementation = ApiResponseDto.class))),
+            @ApiResponse(responseCode = "401", description = "인증 미완료 / 재발송됨",
+                    content = @Content(schema = @Schema(implementation = ApiResponseDto.class)))
+    })
     @GetMapping("/email/send-code")
-    public RedirectView verifyEmail(@RequestParam String code) {
+    public RedirectView verifyEmail(
+            @Parameter(name = "code", description = "이메일 인증 코드", required = true, in = ParameterIn.QUERY,
+                    examples = @ExampleObject(value = "a7b9c-...-uuid"))
+            @RequestParam String code
+    ) {
         boolean result = emailVerificationService.verifyEmailCode(code);
         String email = emailVerificationService.findVerifiedEmailByCode(code);
-
-        if (result) {
-            authService.setEmailVerificationService(email);
-        }
-
+        if (result) authService.setEmailVerificationService(email);
         RedirectView redirectView = new RedirectView();
         redirectView.setUrl("http://localhost:5173/sign-in");
         return redirectView;
     }
 
-    @Operation(summary = "로그인")
+    @Operation(
+            summary = "로그인",
+            description = "이메일/비밀번호로 로그인합니다. Access Token은 본문에, Refresh Token은 HttpOnly 쿠키로 반환됩니다.",
+            requestBody = @RequestBody(
+                    required = true,
+                    content = @Content(
+                            schema = @Schema(implementation = SignInRequest.class),
+                            examples = @ExampleObject(value = """
+                { "email": "test@test.com", "password": "1Q2w3e4r!@#" }
+                """)
+                    )
+            )
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "로그인 성공",
+                    content = @Content(schema = @Schema(implementation = ApiResponseDto.class),
+                            examples = @ExampleObject(value = """
+                {
+                  "status": 200,
+                  "message": "로그인에 성공했습니다.",
+                  "data": {
+                    "accessToken": "eyJhbGciOi...",
+                    "user": {
+                      "id": 1, "username": "홍길동", "email": "test@test.com",
+                      "nickname": "고통스러운 개발자", "profileImageUrl": "https://...",
+                      "mainPosition": "백엔드", "IsPreference": true,
+                      "location": { "latitude": 37.5665, "longitude": 126.9780, "address": "서울..." }
+                    }
+                  }
+                }
+                """))),
+            @ApiResponse(responseCode = "401", description = "아이디/비밀번호 불일치 또는 이메일 미인증/재발송",
+                    content = @Content(schema = @Schema(implementation = ApiResponseDto.class)))
+    })
     @PostMapping("/signin")
     public ResponseEntity<ApiResponseDto<SignInResponse>> signIn(
             @Valid @RequestBody SignInRequest signInRequest,
             HttpServletResponse servletResponse
     ) {
-        // 1. 서비스에서 로그인 + 토큰 2개 발급
         SignInResponse response = authService.signIn(signInRequest, servletResponse);
-
-        // ★ Sentry Scope에 유저 정보 세팅
         sentryUserContextService.setCurrentUserContext();
-
-        // ★ Sentry 메시지로 로그인 이벤트 기록
         Sentry.captureMessage(
                 "로그인: " + response.getUser().getUsername() + ": " + response.getUser().getNickname(),
                 SentryLevel.INFO
         );
-
-        // response(본문)는 AccessToken만, RefreshToken은 쿠키로 헤더에 내려감!
         return ResponseEntity.ok(ApiResponseDto.of(200, "로그인에 성공했습니다.", response));
     }
 
-    @Operation(summary = "로그아웃", security = @SecurityRequirement(name = "Authorization"))
+    @Operation(
+            summary = "로그아웃",
+            description = "Access Token 유효성을 검증하고 서버 저장 Refresh Token을 삭제합니다.",
+            security = @SecurityRequirement(name = "Authorization"),
+            parameters = {
+                    @Parameter(name = "Authorization", in = ParameterIn.HEADER, required = true,
+                            description = "Bearer {accessToken}",
+                            examples = @ExampleObject(value = "Bearer eyJhbGciOi..."))
+            }
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "로그아웃 성공",
+                    content = @Content(schema = @Schema(implementation = ApiResponseDto.class),
+                            examples = @ExampleObject(value = """
+                { "status": 200, "message": "로그아웃 되었습니다.", "data": null }
+                """))),
+            @ApiResponse(responseCode = "401", description = "토큰 누락/유효하지 않음",
+                    content = @Content(schema = @Schema(implementation = ApiResponseDto.class)))
+    })
     @PostMapping("/signout")
     public ResponseEntity<ApiResponseDto<Void>> signOut(
             @RequestHeader("Authorization") String authorizationHeader,
             HttpServletResponse response
     ) {
         authService.signOut(authorizationHeader, response);
-
-        // 1. 토큰에서 유저 정보 추출해서 Sentry 컨텍스트 세팅 & username 반환
         String usernameWithNickname = sentryUserContextService.setUserContextFromToken(authorizationHeader);
-
-        // 2. 누가 로그아웃했는지 메시지 기록
         Sentry.captureMessage("로그아웃: " + usernameWithNickname, SentryLevel.INFO);
-
-        // 3. Sentry Scope에서 유저 정보 제거
         sentryUserContextService.clearUserContext();
-
         return ResponseEntity.ok(ApiResponseDto.of(200, "로그아웃 되었습니다.", null));
     }
 
-    @Operation(summary = "이메일(아이디) 찾기")
+    @Operation(
+            summary = "이메일(아이디) 찾기",
+            description = "휴대폰 인증(코드 검증) 후 이름+전화번호로 가입 이메일을 조회합니다.",
+            requestBody = @RequestBody(
+                    required = true,
+                    content = @Content(
+                            schema = @Schema(implementation = FindEmailRequest.class),
+                            examples = @ExampleObject(value = """
+                { "username": "홍길동", "phoneNumber": "01012345678", "phoneCode": "012345" }
+                """)
+                    )
+            )
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공",
+                    content = @Content(schema = @Schema(implementation = ApiResponseDto.class),
+                            examples = @ExampleObject(value = """
+                { "status": 200, "message": "이메일(아이디)을 찾았습니다.", "data": { "email": "test@test.com" } }
+                """))),
+            @ApiResponse(responseCode = "404", description = "인증기록 없음 / 사용자 없음",
+                    content = @Content(schema = @Schema(implementation = ApiResponseDto.class))),
+            @ApiResponse(responseCode = "409", description = "해당 인증 요청이 이미 검증됨",
+                    content = @Content(schema = @Schema(implementation = ApiResponseDto.class)))
+    })
     @PostMapping("/email/find")
     public ResponseEntity<ApiResponseDto<FindEmailResponse>> findEmail(@Valid @RequestBody FindEmailRequest request) {
         FindEmailResponse response = new FindEmailResponse(authService.findEmail(request));
         return ResponseEntity.ok(ApiResponseDto.of(200, "이메일(아이디)을 찾았습니다.", response));
     }
 
-    @Operation(summary = "비밀번호 변경 전 본인 인증")
+    @Operation(
+            summary = "비밀번호 변경 전 본인 인증",
+            description = "이름/이메일/전화번호/인증코드 검증 후 재인증 토큰(reauthToken)을 발급합니다.",
+            requestBody = @RequestBody(
+                    required = true,
+                    content = @Content(
+                            schema = @Schema(implementation = PasswordVerifyUserRequest.class),
+                            examples = @ExampleObject(value = """
+                {
+                  "username": "홍길동",
+                  "email": "test@test.com",
+                  "phoneNumber": "01012345678",
+                  "phoneCode": "012345"
+                }
+                """)
+                    )
+            )
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "본인 인증 성공 (reauthToken 발급)",
+                    content = @Content(schema = @Schema(implementation = ApiResponseDto.class),
+                            examples = @ExampleObject(value = """
+                { "status": 200, "message": "본인 인증에 성공했습니다.", "data": { "reauthToken": "REAUTH_TOKEN_VALUE" } }
+                """))),
+            @ApiResponse(responseCode = "404", description = "인증기록 없음 / 사용자 없음",
+                    content = @Content(schema = @Schema(implementation = ApiResponseDto.class))),
+            @ApiResponse(responseCode = "409", description = "이미 인증된 요청",
+                    content = @Content(schema = @Schema(implementation = ApiResponseDto.class)))
+    })
     @PostMapping("/password/verify-user")
     public ResponseEntity<ApiResponseDto<PasswordVerifyUserResponse>> verifyUser(@Valid @RequestBody PasswordVerifyUserRequest request) {
         String reauthToken = authService.passwordVerifyUser(request);
@@ -162,7 +377,38 @@ public class AuthController {
         return ResponseEntity.ok(ApiResponseDto.of(200, "본인 인증에 성공했습니다.", response));
     }
 
-    @Operation(summary = "비밀번호 재설정", security = @SecurityRequirement(name = "Authorization"))
+    @Operation(
+            summary = "비밀번호 재설정",
+            description = "발급받은 reauthToken(Bearer)으로 검증 후 새 비밀번호로 재설정합니다.",
+            security = @SecurityRequirement(name = "Authorization"),
+            parameters = {
+                    @Parameter(name = "Authorization", in = ParameterIn.HEADER, required = true,
+                            description = "Bearer {reauthToken}",
+                            examples = @ExampleObject(value = "Bearer eyJhbGciOi..."))
+            },
+            requestBody = @RequestBody(
+                    required = true,
+                    content = @Content(
+                            schema = @Schema(implementation = PasswordResetRequest.class),
+                            examples = @ExampleObject(value = """
+                { "newPassword": "!@#123qweR", "passwordCheck": "!@#123qweR" }
+                """)
+                    )
+            )
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "재설정 성공",
+                    content = @Content(schema = @Schema(implementation = ApiResponseDto.class),
+                            examples = @ExampleObject(value = """
+                { "status": 200, "message": "비밀번호가 재설정되었습니다.", "data": null }
+                """))),
+            @ApiResponse(responseCode = "400", description = "비밀번호 불일치 등 입력 오류",
+                    content = @Content(schema = @Schema(implementation = ApiResponseDto.class))),
+            @ApiResponse(responseCode = "401", description = "토큰 누락/유효하지 않음/검증 미완료",
+                    content = @Content(schema = @Schema(implementation = ApiResponseDto.class))),
+            @ApiResponse(responseCode = "404", description = "인증 기록 또는 사용자 없음",
+                    content = @Content(schema = @Schema(implementation = ApiResponseDto.class)))
+    })
     @PostMapping("/password/reset")
     public ResponseEntity<ApiResponseDto<Void>> resetPassword(
             @Valid @RequestBody PasswordResetRequest request,
@@ -172,7 +418,26 @@ public class AuthController {
         return ResponseEntity.ok(ApiResponseDto.of(200, "비밀번호가 재설정되었습니다.", null));
     }
 
-    @Operation(summary = "AccessToken 재발급")
+    @Operation(
+            summary = "AccessToken 재발급",
+            description = "HttpOnly 쿠키에 담긴 Refresh Token을 검증하고 새로운 Access Token을 발급합니다.",
+            parameters = {
+                    @Parameter(name = "refreshToken", in = ParameterIn.COOKIE, required = true,
+                            description = "HttpOnly Refresh Token 쿠키",
+                            examples = @ExampleObject(value = "eyJhbGciOi..."))
+            }
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "재발급 성공",
+                    content = @Content(schema = @Schema(implementation = ApiResponseDto.class),
+                            examples = @ExampleObject(value = """
+                { "status": 200, "message": "토큰 재발급에 성공했습니다.", "data": { "accessToken": "eyJhbGciOi..." } }
+                """))),
+            @ApiResponse(responseCode = "401", description = "리프레시 토큰 유효하지 않음/만료",
+                    content = @Content(schema = @Schema(implementation = ApiResponseDto.class))),
+            @ApiResponse(responseCode = "404", description = "사용자/토큰 정보 없음",
+                    content = @Content(schema = @Schema(implementation = ApiResponseDto.class)))
+    })
     @PostMapping("/token")
     public ResponseEntity<ApiResponseDto<TokenResponse>> reissueAccessToken(
             @CookieValue("refreshToken") String refreshToken
@@ -182,7 +447,62 @@ public class AuthController {
         return ResponseEntity.ok(ApiResponseDto.of(200, "토큰 재발급에 성공했습니다.", response));
     }
 
-    @Operation(summary = "개인화 설정 생성")
+    @Operation(
+            summary = "개인화 설정 생성",
+            description = "대표/관심 포지션, 기술스택, 위치, 특성, 생년월일, 활동시간을 등록합니다.",
+            security = @SecurityRequirement(name = "Authorization"),
+            requestBody = @RequestBody(
+                    required = true,
+                    content = @Content(
+                            schema = @Schema(implementation = PreferenceRequest.class),
+                            examples = @ExampleObject(value = """
+                {
+                  "mainPosition": "백엔드",
+                  "subPosition": ["프론트엔드", "데브옵스"],
+                  "techStacks": ["Java", "Spring Boot", "React"],
+                  "location": { "latitude": 37.5665, "longitude": 126.9780, "address": "서울..." },
+                  "traits": ["협업", "문제 해결"],
+                  "birthDate": "1997-10-10",
+                  "activeHours": { "start": "19", "end": "23" }
+                }
+                """)
+                    )
+            )
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "생성 성공",
+                    content = @Content(schema = @Schema(implementation = ApiResponseDto.class),
+                            examples = @ExampleObject(value = """
+                {
+                  "status": 201,
+                  "message": "개인화 설정이 완료되었습니다.",
+                  "data": {
+                    "id": 1,
+                    "username": "홍길동",
+                    "email": "test@test.com",
+                    "mainPosition": "백엔드",
+                    "profileImageUrl": "https://...",
+                    "nickname": "백엔드_호랑이",
+                    "isPreferences": true,
+                    "preferences": {
+                      "mainPosition": "백엔드",
+                      "subPosition": ["프론트엔드", "데브옵스"],
+                      "techStacks": ["Java", "Spring Boot", "React"],
+                      "location": { "latitude": 37.5665, "longitude": 126.9780, "address": "서울..." },
+                      "traits": ["협업", "문제 해결"],
+                      "birthDate": "1997-10-10",
+                      "activeHours": { "start": "19", "end": "23" }
+                    }
+                  }
+                }
+                """))),
+            @ApiResponse(responseCode = "400", description = "입력값 유효성 실패",
+                    content = @Content(schema = @Schema(implementation = ApiResponseDto.class))),
+            @ApiResponse(responseCode = "401", description = "인증 필요",
+                    content = @Content(schema = @Schema(implementation = ApiResponseDto.class))),
+            @ApiResponse(responseCode = "404", description = "사용자 없음",
+                    content = @Content(schema = @Schema(implementation = ApiResponseDto.class)))
+    })
     @PostMapping("/preference")
     public ResponseEntity<ApiResponseDto<PreferenceResponse>> createPreference(
             @AuthenticationPrincipal CustomUserDetails user,

--- a/src/main/java/goorm/ddok/member/controller/AuthController.java
+++ b/src/main/java/goorm/ddok/member/controller/AuthController.java
@@ -2,6 +2,7 @@ package goorm.ddok.member.controller;
 
 
 import goorm.ddok.global.response.ApiResponseDto;
+import goorm.ddok.global.security.auth.CustomUserDetails;
 import goorm.ddok.global.util.sentry.SentryUserContextService;
 import goorm.ddok.member.dto.request.*;
 import goorm.ddok.member.dto.response.*;
@@ -18,8 +19,11 @@ import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.view.RedirectView;
+
+import java.net.URI;
 
 @RestController
 @RequiredArgsConstructor
@@ -178,5 +182,15 @@ public class AuthController {
         String result = tokenService.reissueAccessToken(refreshToken);
         TokenResponse response = new TokenResponse(result);
         return ResponseEntity.ok(ApiResponseDto.of(200, "토큰 재발급에 성공했습니다.", response));
+    }
+
+    @Operation(summary = "개인화 설정 생성")
+    @PostMapping("/preference")
+    public ResponseEntity<ApiResponseDto<PreferenceResponse>> createPreference(
+            @AuthenticationPrincipal CustomUserDetails user,
+            @Valid @RequestBody PreferenceRequest request
+    ) {
+        PreferenceResponse response = authService.createPreference(user.getId(), request);
+        return ResponseEntity.ok(ApiResponseDto.of(201, "개인화 설정이 완료되었습니다.", response));
     }
 }

--- a/src/main/java/goorm/ddok/member/controller/AuthController.java
+++ b/src/main/java/goorm/ddok/member/controller/AuthController.java
@@ -23,8 +23,6 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.view.RedirectView;
 
-import java.net.URI;
-
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/auth")

--- a/src/main/java/goorm/ddok/member/domain/UserActivity.java
+++ b/src/main/java/goorm/ddok/member/domain/UserActivity.java
@@ -26,7 +26,6 @@ public class UserActivity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    /** User와 1:1, PK 공유 */
     @OneToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "user_id", nullable = false, unique = true)
     private User user;

--- a/src/main/java/goorm/ddok/member/domain/UserActivity.java
+++ b/src/main/java/goorm/ddok/member/domain/UserActivity.java
@@ -32,10 +32,14 @@ public class UserActivity {
     private User user;
 
     @Column(name = "activity_start_time", nullable = false)
-    private Instant activityStartTime;
+    @jakarta.validation.constraints.Min(0)
+    @jakarta.validation.constraints.Max(24)
+    private Integer activityStartTime;
 
     @Column(name = "activity_end_time", nullable = false)
-    private Instant activityEndTime;
+    @jakarta.validation.constraints.Min(0)
+    @jakarta.validation.constraints.Max(24)
+    private Integer activityEndTime;
 
     @CreatedDate
     @Column(name = "created_at", nullable = false, updatable = false)

--- a/src/main/java/goorm/ddok/member/domain/UserActivity.java
+++ b/src/main/java/goorm/ddok/member/domain/UserActivity.java
@@ -17,7 +17,7 @@ import java.time.Instant;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
-@Builder
+@Builder(toBuilder = true)
 @EntityListeners(AuditingEntityListener.class)
 @Check(constraints = "activity_end_time >= activity_start_time")
 public class UserActivity {

--- a/src/main/java/goorm/ddok/member/dto/request/ActiveHoursRequest.java
+++ b/src/main/java/goorm/ddok/member/dto/request/ActiveHoursRequest.java
@@ -1,12 +1,8 @@
 package goorm.ddok.member.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Pattern;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import jakarta.validation.constraints.*;
+import lombok.*;
 
 @Data
 @NoArgsConstructor
@@ -15,13 +11,13 @@ import lombok.NoArgsConstructor;
 @Schema(description = "활동 시간 요청 DTO")
 public class ActiveHoursRequest {
 
-    @Schema(description = "시작 시간", example = "09")
+    @Schema(description = "시작 시간(00~24)", example = "09")
     @NotBlank(message = "시작 시간은 필수 입력 값입니다.")
     @Pattern(regexp = "^(?:[01]\\d|2[0-4])$", message = "시간은 00~24 사이의 값이어야 합니다.")
     private String start;
 
-    @Schema(description = "종료 시간", example = "18")
+    @Schema(description = "종료 시간(00~24)", example = "18")
     @NotBlank(message = "종료 시간은 필수 입력 값입니다.")
-    @Pattern(regexp = "^(?:[01]\\d|2[0-3])$", message = "시간은 00~24 사이의 값이어야 합니다.")
+    @Pattern(regexp = "^(?:[01]\\d|2[0-4])$", message = "시간은 00~24 사이의 값이어야 합니다.")
     private String end;
 }

--- a/src/main/java/goorm/ddok/member/dto/request/ActiveHoursRequest.java
+++ b/src/main/java/goorm/ddok/member/dto/request/ActiveHoursRequest.java
@@ -1,0 +1,27 @@
+package goorm.ddok.member.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Schema(description = "활동 시간 요청 DTO")
+public class ActiveHoursRequest {
+
+    @Schema(description = "시작 시간", example = "09")
+    @NotBlank(message = "시작 시간은 필수 입력 값입니다.")
+    @Pattern(regexp = "^(?:[01]\\d|2[0-4])$", message = "시간은 00~24 사이의 값이어야 합니다.")
+    private String start;
+
+    @Schema(description = "종료 시간", example = "18")
+    @NotBlank(message = "종료 시간은 필수 입력 값입니다.")
+    @Pattern(regexp = "^(?:[01]\\d|2[0-3])$", message = "시간은 00~24 사이의 값이어야 합니다.")
+    private String end;
+}

--- a/src/main/java/goorm/ddok/member/dto/request/ActiveHoursRequest.java
+++ b/src/main/java/goorm/ddok/member/dto/request/ActiveHoursRequest.java
@@ -8,15 +8,39 @@ import lombok.*;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-@Schema(description = "활동 시간 요청 DTO")
+@Schema(
+        name = "ActiveHoursRequest",
+        description = "활동 시간 요청 DTO (24시간 기반, 문자열 HH 형식)",
+        requiredProperties = {"start", "end"},
+        example = """
+    {
+      "start": "09",
+      "end": "18"
+    }
+    """
+)
 public class ActiveHoursRequest {
 
-    @Schema(description = "시작 시간(00~24)", example = "09")
+    @Schema(
+            description = "시작 시간 (00~24, 두 자리 문자열)",
+            example = "09",
+            pattern = "^(?:[01]\\d|2[0-4])$",
+            minLength = 2,
+            maxLength = 2,
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
     @NotBlank(message = "시작 시간은 필수 입력 값입니다.")
     @Pattern(regexp = "^(?:[01]\\d|2[0-4])$", message = "시간은 00~24 사이의 값이어야 합니다.")
     private String start;
 
-    @Schema(description = "종료 시간(00~24)", example = "18")
+    @Schema(
+            description = "종료 시간 (00~24, 두 자리 문자열)",
+            example = "18",
+            pattern = "^(?:[01]\\d|2[0-4])$",
+            minLength = 2,
+            maxLength = 2,
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
     @NotBlank(message = "종료 시간은 필수 입력 값입니다.")
     @Pattern(regexp = "^(?:[01]\\d|2[0-4])$", message = "시간은 00~24 사이의 값이어야 합니다.")
     private String end;

--- a/src/main/java/goorm/ddok/member/dto/request/EmailCheckRequest.java
+++ b/src/main/java/goorm/ddok/member/dto/request/EmailCheckRequest.java
@@ -8,11 +8,26 @@ import lombok.Setter;
 
 @Getter
 @Setter
-@Schema(description = "이메일 중복 확인 요청 DTO")
+@Schema(
+        name = "EmailCheckRequest",
+        description = "이메일 중복 확인 요청 DTO",
+        requiredProperties = {"email"},
+        example = """
+    {
+      "email": "test@test.com"
+    }
+    """
+)
 public class EmailCheckRequest {
 
     @NotBlank
     @Email
-    @Schema(description = "가입할 이메일", example = "test@test.com")
+    @Schema(
+            description = "가입할 이메일",
+            example = "test@test.com",
+            type = "string",
+            format = "email",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
     private String email;
 }

--- a/src/main/java/goorm/ddok/member/dto/request/FindEmailRequest.java
+++ b/src/main/java/goorm/ddok/member/dto/request/FindEmailRequest.java
@@ -8,19 +8,45 @@ import lombok.Setter;
 
 @Getter
 @Setter
-@Schema(description = "아이디(이메일) 찾기 요청 DTO")
+@Schema(
+        name = "FindEmailRequest",
+        description = "아이디(이메일) 찾기 요청 DTO",
+        requiredProperties = {"username", "phoneNumber", "phoneCode"},
+        example = """
+    {
+      "username": "홍길동",
+      "phoneNumber": "01012345678",
+      "phoneCode": "012345"
+    }
+    """
+)
 public class FindEmailRequest {
 
     @NotBlank(message = "이름 입력이 누락되었습니다.")
-    @Schema(description = "사용자 이름", example = "홍길동")
+    @Schema(
+            description = "사용자 이름",
+            example = "홍길동",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
     private String username;
 
     @NotBlank(message = "전화번호 입력이 누락되었습니다.")
     @Pattern(regexp = "^01[0-9]\\d{7,8}$", message = "올바른 형식의 전화번호여야 합니다.")
+    @Schema(
+            description = "전화번호(010으로 시작, 숫자 10~11자리)",
+            example = "01012345678",
+            pattern = "^01[0-9]\\d{7,8}$",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
     private String phoneNumber;
 
     @NotBlank(message = "인증코드 입력이 누락되었습니다.")
     @Pattern(regexp = "^\\d{6}$", message = "인증번호는 숫자 6자리여야 합니다.")
-    @Schema(description = "인증코드", example = "012345")
+    @Schema(
+            description = "인증코드(숫자 6자리)",
+            example = "012345",
+            pattern = "^\\d{6}$",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
     private String phoneCode;
 }

--- a/src/main/java/goorm/ddok/member/dto/request/LocationRequest.java
+++ b/src/main/java/goorm/ddok/member/dto/request/LocationRequest.java
@@ -1,10 +1,8 @@
 package goorm.ddok.member.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import jakarta.validation.constraints.*;
+import lombok.*;
 
 @Data
 @NoArgsConstructor
@@ -14,11 +12,18 @@ import lombok.NoArgsConstructor;
 public class LocationRequest {
 
     @Schema(description = "위도", example = "37.5665")
-    private double latitude;
+    @NotNull(message = "위도는 필수 입력 값입니다.")
+    @DecimalMin(value = "-90.0", message = "위도는 -90.0 이상이어야 합니다.")
+    @DecimalMax(value = "90.0", message = "위도는 90.0 이하이어야 합니다.")
+    private Double latitude;
 
     @Schema(description = "경도", example = "126.9780")
-    private double longitude;
+    @NotNull(message = "경도는 필수 입력 값입니다.")
+    @DecimalMin(value = "-180.0", message = "경도는 -180.0 이상이어야 합니다.")
+    @DecimalMax(value = "180.0", message = "경도는 180.0 이하이어야 합니다.")
+    private Double longitude;
 
     @Schema(description = "주소", example = "서울특별시 강남구 테헤란로 123")
+    @NotBlank(message = "주소는 필수 입력 값입니다.")
     private String address;
 }

--- a/src/main/java/goorm/ddok/member/dto/request/LocationRequest.java
+++ b/src/main/java/goorm/ddok/member/dto/request/LocationRequest.java
@@ -1,0 +1,24 @@
+package goorm.ddok.member.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Schema(description = "위치 정보 요청 DTO")
+public class LocationRequest {
+
+    @Schema(description = "위도", example = "37.5665")
+    private double latitude;
+
+    @Schema(description = "경도", example = "126.9780")
+    private double longitude;
+
+    @Schema(description = "주소", example = "서울특별시 강남구 테헤란로 123")
+    private String address;
+}

--- a/src/main/java/goorm/ddok/member/dto/request/LocationRequest.java
+++ b/src/main/java/goorm/ddok/member/dto/request/LocationRequest.java
@@ -8,22 +8,54 @@ import lombok.*;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-@Schema(description = "위치 정보 요청 DTO")
+@Schema(
+        name = "LocationRequest",
+        description = "위치 정보 요청 DTO",
+        requiredProperties = {"latitude", "longitude", "address"},
+        example = """
+    {
+      "latitude": 37.5665,
+      "longitude": 126.9780,
+      "address": "서울특별시 강남구 테헤란로 123"
+    }
+    """
+)
 public class LocationRequest {
 
-    @Schema(description = "위도", example = "37.5665")
+    @Schema(
+            description = "위도",
+            example = "37.5665",
+            minimum = "-90.0",
+            maximum = "90.0",
+            type = "number",
+            format = "double",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
     @NotNull(message = "위도는 필수 입력 값입니다.")
     @DecimalMin(value = "-90.0", message = "위도는 -90.0 이상이어야 합니다.")
     @DecimalMax(value = "90.0", message = "위도는 90.0 이하이어야 합니다.")
     private Double latitude;
 
-    @Schema(description = "경도", example = "126.9780")
+    @Schema(
+            description = "경도",
+            example = "126.9780",
+            minimum = "-180.0",
+            maximum = "180.0",
+            type = "number",
+            format = "double",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
     @NotNull(message = "경도는 필수 입력 값입니다.")
     @DecimalMin(value = "-180.0", message = "경도는 -180.0 이상이어야 합니다.")
     @DecimalMax(value = "180.0", message = "경도는 180.0 이하이어야 합니다.")
     private Double longitude;
 
-    @Schema(description = "주소", example = "서울특별시 강남구 테헤란로 123")
+    @Schema(
+            description = "주소",
+            example = "서울특별시 강남구 테헤란로 123",
+            type = "string",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
     @NotBlank(message = "주소는 필수 입력 값입니다.")
     private String address;
 }

--- a/src/main/java/goorm/ddok/member/dto/request/PasswordResetRequest.java
+++ b/src/main/java/goorm/ddok/member/dto/request/PasswordResetRequest.java
@@ -7,14 +7,42 @@ import lombok.Setter;
 
 @Getter
 @Setter
-@Schema(description = "비밀번호 변경 요청 DTO")
+@Schema(
+        name = "PasswordResetRequest",
+        description = "비밀번호 변경 요청 DTO",
+        requiredProperties = {"newPassword", "passwordCheck"},
+        example = """
+    {
+      "newPassword": "!@#123qweR",
+      "passwordCheck": "!@#123qweR"
+    }
+    """
+)
 public class PasswordResetRequest {
 
     @NotBlank(message = "비밀번호 입력이 누락되었습니다.")
-    @Schema(description = "새로운 비밀번호", example = "!@#123qweR")
+    @Schema(
+            description = "새로운 비밀번호",
+            example = "!@#123qweR",
+            type = "string",
+            format = "password",
+            // 문서화용 패턴(서버 검증은 아님). 필요 시 실제 검증은 @Pattern 추가
+            pattern = "^(?=.*[A-Z])(?=.*[a-z])(?=.*\\d)(?=.*[^\\w\\s]).{8,64}$",
+            minLength = 8,
+            maxLength = 64,
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
     private String newPassword;
 
     @NotBlank(message = "비밀번호 확인 입력이 누락되었습니다.")
-    @Schema(description = "새로운 비밀번호 확인", example = "!@#123qweR")
+    @Schema(
+            description = "새로운 비밀번호 확인",
+            example = "!@#123qweR",
+            type = "string",
+            format = "password",
+            minLength = 8,
+            maxLength = 64,
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
     private String passwordCheck;
 }

--- a/src/main/java/goorm/ddok/member/dto/request/PasswordVerifyUserRequest.java
+++ b/src/main/java/goorm/ddok/member/dto/request/PasswordVerifyUserRequest.java
@@ -9,23 +9,57 @@ import lombok.Setter;
 
 @Getter
 @Setter
-@Schema(description = "비밀번호 찾기 본인 인증 및 reauthToken 발급 DTO")
+@Schema(
+        name = "PasswordVerifyUserRequest",
+        description = "비밀번호 찾기 본인 인증 및 reauthToken 발급 DTO",
+        requiredProperties = {"username", "email", "phoneNumber", "phoneCode"},
+        example = """
+    {
+      "username": "홍길동",
+      "email": "test@test.com",
+      "phoneNumber": "01012345678",
+      "phoneCode": "012345"
+    }
+    """
+)
 public class PasswordVerifyUserRequest {
 
     @NotBlank(message = "이름 입력이 누락되었습니다.")
-    @Schema(description = "사용자 이름", example = "홍길동")
+    @Schema(
+            description = "사용자 이름",
+            example = "홍길동",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
     private String username;
 
     @NotBlank(message = "이메일 입력이 누락되었습니다.")
     @Email
-    @Schema(description = "가입한 이메일", example = "test@test.com")
+    @Schema(
+            description = "가입한 이메일",
+            example = "test@test.com",
+            type = "string",
+            format = "email",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
     private String email;
 
     @NotBlank(message = "전화번호 입력이 누락되었습니다.")
     @Pattern(regexp = "^01[0-9]\\d{7,8}$", message = "올바른 형식의 전화번호여야 합니다.")
+    @Schema(
+            description = "전화번호(010 시작, 숫자 10~11자리)",
+            example = "01012345678",
+            pattern = "^01[0-9]\\d{7,8}$",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
     private String phoneNumber;
 
     @NotBlank(message = "인증번호 입력이 누락되었습니다.")
     @Pattern(regexp = "^\\d{6}$", message = "인증번호는 숫자 6자리여야 합니다.")
+    @Schema(
+            description = "인증번호(숫자 6자리)",
+            example = "012345",
+            pattern = "^\\d{6}$",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
     private String phoneCode;
 }

--- a/src/main/java/goorm/ddok/member/dto/request/PhoneVerificationRequest.java
+++ b/src/main/java/goorm/ddok/member/dto/request/PhoneVerificationRequest.java
@@ -9,18 +9,44 @@ import lombok.Setter;
 
 @Getter
 @Setter
-@Schema(description = "휴대폰 번호 인증 발송 DTO")
+@Schema(
+        name = "PhoneVerificationRequest",
+        description = "휴대폰 번호 인증 발송 DTO",
+        requiredProperties = {"phoneNumber", "username", "authType"},
+        example = """
+    {
+      "phoneNumber": "01012345678",
+      "username": "홍길동",
+      "authType": "SIGN_UP"
+    }
+    """
+)
 public class PhoneVerificationRequest {
 
     @NotBlank(message = "전화번호 입력이 누락되었습니다.")
-    @Schema(description = "전화번호", example = "01012345678")
+    @Schema(
+            description = "전화번호(010 시작, 숫자 11자리)",
+            example = "01012345678",
+            pattern = "^010\\d{8}$",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
     private String phoneNumber;
 
     @NotBlank(message = "이름 입력이 누락되었습니다.")
-    @Schema(description = "사용자 이름", example = "홍길동")
+    @Schema(
+            description = "사용자 이름",
+            example = "홍길동",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
     private String username;
 
     @NotNull(message = "인증 타입이 누락되었습니다.")
-    @Schema(description = "인증 타입", example = "SIGN_UP / FIND_ID / FIND_PASSWORD")
+    @Schema(
+            description = "인증 타입",
+            implementation = AuthType.class,
+            allowableValues = {"SIGN_UP", "FIND_ID", "FIND_PASSWORD"},
+            example = "SIGN_UP",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
     private AuthType authType;
 }

--- a/src/main/java/goorm/ddok/member/dto/request/PhoneVerifyCodeRequest.java
+++ b/src/main/java/goorm/ddok/member/dto/request/PhoneVerifyCodeRequest.java
@@ -8,13 +8,36 @@ import lombok.Setter;
 
 @Getter
 @Setter
-@Schema(description = "휴대폰 인증 코드 요청 DTO")
+@Schema(
+        name = "PhoneVerifyCodeRequest",
+        description = "휴대폰 인증 코드 요청 DTO",
+        requiredProperties = {"phoneNumber", "phoneCode"},
+        example = """
+    {
+      "phoneNumber": "01012345678",
+      "phoneCode": "123456"
+    }
+    """
+)
 public class PhoneVerifyCodeRequest {
+
     @NotBlank(message = "전화번호는 필수 입력입니다.")
     @Pattern(regexp = "^01[0-9]\\d{7,8}$", message = "올바른 형식의 전화번호여야 합니다.")
+    @Schema(
+            description = "전화번호(010 시작, 숫자 10~11자리)",
+            example = "01012345678",
+            pattern = "^01[0-9]\\d{7,8}$",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
     private String phoneNumber;
 
     @NotBlank(message = "인증번호는 필수 입력입니다.")
     @Pattern(regexp = "^\\d{6}$", message = "인증번호는 숫자 6자리여야 합니다.")
+    @Schema(
+            description = "인증번호(숫자 6자리)",
+            example = "123456",
+            pattern = "^\\d{6}$",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
     private String phoneCode;
 }

--- a/src/main/java/goorm/ddok/member/dto/request/PreferenceRequest.java
+++ b/src/main/java/goorm/ddok/member/dto/request/PreferenceRequest.java
@@ -1,15 +1,12 @@
 package goorm.ddok.member.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.time.LocalDate;
 import java.util.List;
-
 
 @Data
 @NoArgsConstructor
@@ -22,30 +19,47 @@ public class PreferenceRequest {
     @NotBlank(message = "대표 포지션은 필수 입력값입니다.")
     private String mainPosition;
 
-    @Schema(description = "관심 포지션", example = "프론트엔드 개발자, 데이터 엔지니어")
+    @Schema(
+            description = "관심 포지션 (정확히 2개)",
+            example = "[\"프론트엔드\", \"데브옵스\"]"
+    )
+    @NotNull(message = "관심 포지션은 필수 입력값입니다.")
     @Size(min = 2, max = 2, message = "관심 포지션은 반드시 2개여야 합니다.")
-    private List<String> subPosition;
+    private List<@NotBlank(message = "관심 포지션 항목은 비어 있을 수 없습니다.") String> subPosition;
 
-    @Schema(description = "기술 스택", example = "Java, Spring Boot, React")
+    @Schema(
+            description = "기술 스택",
+            example = "[\"Java\", \"Spring Boot\", \"React\"]"
+    )
+    // @NotEmpty(message = "기술 스택은 최소 1개 이상 입력해야 합니다.")
     private List<String> techStacks;
 
-    @Schema(description = "위치 정보 요청 DTO", example = "{ \"latitude\": 37.5665, \"longitude\": 126.9780, \"address\": \"서울특별시 강남구 테헤란로 123\" }")
+    @Schema(
+            description = "위치 정보 요청 DTO",
+            example = "{ \"latitude\": 37.5665, \"longitude\": 126.9780, \"address\": \"서울특별시 강남구 테헤란로 123\" }"
+    )
     @NotNull(message = "위치 정보는 필수 입력값입니다.")
+    @Valid
     private LocationRequest location;
 
-    @Schema(description = "특성 리스트", example = "[\"협업\", \"문제 해결\"]")
+    @Schema(
+            description = "특성 리스트 (1~5개)",
+            example = "[\"협업\", \"문제 해결\"]"
+    )
     @NotNull(message = "특성(traits)은 필수 입력 값입니다.")
     @Size(min = 1, max = 5, message = "특성(traits)은 최소 1개, 최대 5개까지 입력 가능합니다.")
-    private List<String> traits;
-
+    private List<@NotBlank(message = "특성 항목은 비어 있을 수 없습니다.") String> traits;
 
     @Schema(description = "생년월일", example = "1990-01-01")
     @NotNull(message = "생년월일은 필수 입력 값입니다.")
     @Past(message = "생년월일은 과거 날짜여야 합니다.")
     private LocalDate birthDate;
 
-    @Schema(description = "활동 시간 요청 DTO", example = "{ \"start\": \"09\", \"end\": \"18\" }")
+    @Schema(
+            description = "활동 시간 요청 DTO (24시간 형식, 00~23)",
+            example = "{ \"start\": \"09\", \"end\": \"18\" }"
+    )
     @NotNull(message = "활동 시간은 필수 입력 값입니다.")
+    @Valid
     private ActiveHoursRequest activeHours;
-
 }

--- a/src/main/java/goorm/ddok/member/dto/request/PreferenceRequest.java
+++ b/src/main/java/goorm/ddok/member/dto/request/PreferenceRequest.java
@@ -1,0 +1,51 @@
+package goorm.ddok.member.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.util.List;
+
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Schema(description = "개인화 설정 요청 DTO")
+public class PreferenceRequest {
+
+    @Schema(description = "대표 포지션", example = "백엔드")
+    @NotBlank(message = "대표 포지션은 필수 입력값입니다.")
+    private String mainPosition;
+
+    @Schema(description = "관심 포지션", example = "프론트엔드 개발자, 데이터 엔지니어")
+    @Size(min = 2, max = 2, message = "관심 포지션은 반드시 2개여야 합니다.")
+    private List<String> subPosition;
+
+    @Schema(description = "기술 스택", example = "Java, Spring Boot, React")
+    private List<String> techStacks;
+
+    @Schema(description = "위치 정보 요청 DTO", example = "{ \"latitude\": 37.5665, \"longitude\": 126.9780, \"address\": \"서울특별시 강남구 테헤란로 123\" }")
+    @NotNull(message = "위치 정보는 필수 입력값입니다.")
+    private LocationRequest location;
+
+    @Schema(description = "특성 리스트", example = "[\"협업\", \"문제 해결\"]")
+    @NotNull(message = "특성(traits)은 필수 입력 값입니다.")
+    @Size(min = 1, max = 5, message = "특성(traits)은 최소 1개, 최대 5개까지 입력 가능합니다.")
+    private List<String> traits;
+
+
+    @Schema(description = "생년월일", example = "1990-01-01")
+    @NotNull(message = "생년월일은 필수 입력 값입니다.")
+    @Past(message = "생년월일은 과거 날짜여야 합니다.")
+    private LocalDate birthDate;
+
+    @Schema(description = "활동 시간 요청 DTO", example = "{ \"start\": \"09\", \"end\": \"18\" }")
+    @NotNull(message = "활동 시간은 필수 입력 값입니다.")
+    private ActiveHoursRequest activeHours;
+
+}

--- a/src/main/java/goorm/ddok/member/dto/request/PreferenceRequest.java
+++ b/src/main/java/goorm/ddok/member/dto/request/PreferenceRequest.java
@@ -1,5 +1,6 @@
 package goorm.ddok.member.dto.request;
 
+import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.*;
@@ -12,52 +13,90 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-@Schema(description = "개인화 설정 요청 DTO")
+@Schema(
+        name = "PreferenceRequest",
+        description = "개인화 설정 요청 DTO",
+        requiredProperties = {"mainPosition", "subPosition", "location", "traits", "birthDate", "activeHours"},
+        example = """
+    {
+      "mainPosition": "백엔드",
+      "subPosition": ["프론트엔드", "데브옵스"],
+      "techStacks": ["Java", "Spring Boot", "React"],
+      "location": { "latitude": 37.5665, "longitude": 126.9780, "address": "서울특별시 강남구 테헤란로 123" },
+      "traits": ["협업", "문제 해결"],
+      "birthDate": "1997-10-10",
+      "activeHours": { "start": "19", "end": "23" }
+    }
+    """
+)
 public class PreferenceRequest {
 
-    @Schema(description = "대표 포지션", example = "백엔드")
+    @Schema(
+            description = "대표 포지션",
+            example = "백엔드",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
     @NotBlank(message = "대표 포지션은 필수 입력값입니다.")
     private String mainPosition;
 
-    @Schema(
-            description = "관심 포지션 (정확히 2개)",
-            example = "[\"프론트엔드\", \"데브옵스\"]"
+    @ArraySchema(
+            minItems = 2,
+            maxItems = 2,
+            uniqueItems = false,
+            arraySchema = @Schema(description = "관심 포지션 (정확히 2개)"),
+            schema = @Schema(description = "관심 포지션 항목", example = "프론트엔드")
     )
     @NotNull(message = "관심 포지션은 필수 입력값입니다.")
     @Size(min = 2, max = 2, message = "관심 포지션은 반드시 2개여야 합니다.")
     private List<@NotBlank(message = "관심 포지션 항목은 비어 있을 수 없습니다.") String> subPosition;
 
-    @Schema(
-            description = "기술 스택",
-            example = "[\"Java\", \"Spring Boot\", \"React\"]"
+    @ArraySchema(
+            arraySchema = @Schema(description = "기술 스택 (선택 입력)"),
+            schema = @Schema(description = "기술 스택 항목", example = "Spring Boot")
     )
     // @NotEmpty(message = "기술 스택은 최소 1개 이상 입력해야 합니다.")
     private List<String> techStacks;
 
     @Schema(
             description = "위치 정보 요청 DTO",
-            example = "{ \"latitude\": 37.5665, \"longitude\": 126.9780, \"address\": \"서울특별시 강남구 테헤란로 123\" }"
+            implementation = LocationRequest.class,
+            requiredMode = Schema.RequiredMode.REQUIRED,
+            example = """
+        { "latitude": 37.5665, "longitude": 126.9780, "address": "서울특별시 강남구 테헤란로 123" }
+        """
     )
     @NotNull(message = "위치 정보는 필수 입력값입니다.")
     @Valid
     private LocationRequest location;
 
-    @Schema(
-            description = "특성 리스트 (1~5개)",
-            example = "[\"협업\", \"문제 해결\"]"
+    @ArraySchema(
+            minItems = 1,
+            maxItems = 5,
+            arraySchema = @Schema(description = "특성 리스트 (1~5개)"),
+            schema = @Schema(description = "특성 항목", example = "협업")
     )
     @NotNull(message = "특성(traits)은 필수 입력 값입니다.")
     @Size(min = 1, max = 5, message = "특성(traits)은 최소 1개, 최대 5개까지 입력 가능합니다.")
     private List<@NotBlank(message = "특성 항목은 비어 있을 수 없습니다.") String> traits;
 
-    @Schema(description = "생년월일", example = "1990-01-01")
+    @Schema(
+            description = "생년월일",
+            example = "1997-10-10",
+            type = "string",
+            format = "date",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
     @NotNull(message = "생년월일은 필수 입력 값입니다.")
     @Past(message = "생년월일은 과거 날짜여야 합니다.")
     private LocalDate birthDate;
 
     @Schema(
-            description = "활동 시간 요청 DTO (24시간 형식, 00~23)",
-            example = "{ \"start\": \"09\", \"end\": \"18\" }"
+            description = "활동 시간 요청 DTO (24시간 형식, 00~24)",
+            implementation = ActiveHoursRequest.class,
+            requiredMode = Schema.RequiredMode.REQUIRED,
+            example = """
+        { "start": "19", "end": "23" }
+        """
     )
     @NotNull(message = "활동 시간은 필수 입력 값입니다.")
     @Valid

--- a/src/main/java/goorm/ddok/member/dto/request/SignInRequest.java
+++ b/src/main/java/goorm/ddok/member/dto/request/SignInRequest.java
@@ -6,15 +6,37 @@ import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 
 @Getter
-@Schema(description = "로그인 요청 DTO")
+@Schema(
+        name = "SignInRequest",
+        description = "로그인 요청 DTO",
+        requiredProperties = {"email", "password"},
+        example = """
+    {
+      "email": "test@test.com",
+      "password": "1Q2w3e4r!@#"
+    }
+    """
+)
 public class SignInRequest {
 
     @NotBlank
     @Email
-    @Schema(description = "가입한 이메일", example = "test@test.com")
+    @Schema(
+            description = "가입한 이메일",
+            example = "test@test.com",
+            type = "string",
+            format = "email",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
     private String email;
 
     @NotBlank
-    @Schema(description = "비밀번호", example = "1Q2w3e4r!@#")
+    @Schema(
+            description = "비밀번호",
+            example = "1Q2w3e4r!@#",
+            type = "string",
+            format = "password", // Swagger UI에서 비밀번호 입력 필드로 렌더링
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
     private String password;
 }

--- a/src/main/java/goorm/ddok/member/dto/request/SignUpRequest.java
+++ b/src/main/java/goorm/ddok/member/dto/request/SignUpRequest.java
@@ -8,30 +8,77 @@ import lombok.Setter;
 
 @Getter
 @Setter
-@Schema(description = "회원가입 요청 DTO")
+@Schema(
+        name = "SignUpRequest",
+        description = "회원가입 요청 DTO",
+        requiredProperties = {"email", "username", "password", "passwordCheck", "phoneNumber", "phoneCode"},
+        example = """
+    {
+      "email": "test@test.com",
+      "username": "홍길동",
+      "password": "1Q2w3e4r!@#",
+      "passwordCheck": "1Q2w3e4r!@#",
+      "phoneNumber": "01012345678",
+      "phoneCode": "828282"
+    }
+    """
+)
 public class SignUpRequest {
+
     @NotBlank(message = "이메일 입력이 누락되었습니다.")
     @Email(message = "유효한 이메일 형식이 아닙니다.")
-    @Schema(description = "사용자 이메일", example = "test@test.com")
+    @Schema(
+            description = "사용자 이메일",
+            example = "test@test.com",
+            type = "string",
+            format = "email",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
     private String email;
 
     @NotBlank(message = "이름 입력이 누락되었습니다.")
-    @Schema(description = "사용자 이름", example = "홍길동")
+    @Schema(
+            description = "사용자 이름",
+            example = "홍길동",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
     private String username;
 
     @NotBlank(message = "비밀번호 입력이 누락되었습니다.")
-    @Schema(description = "비밀번호", example = "1Q2w3e4r!@#")
+    @Schema(
+            description = "비밀번호",
+            example = "1Q2w3e4r!@#",
+            type = "string",
+            format = "password",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
     private String password;
 
     @NotBlank(message = "비밀번호 확인 입력이 누락되었습니다.")
-    @Schema(description = "비밀번호 확인", example = "1Q2w3e4r!@#")
+    @Schema(
+            description = "비밀번호 확인",
+            example = "1Q2w3e4r!@#",
+            type = "string",
+            format = "password",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
     private String passwordCheck;
 
     @NotBlank(message = "전화번호 입력이 누락되었습니다.")
-    @Schema(description = "전화번호", example = "01012345678")
+    @Schema(
+            description = "전화번호(숫자만, 010으로 시작 · 총 11자리)",
+            example = "01012345678",
+            pattern = "^010\\d{8}$",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
     private String phoneNumber;
 
     @NotBlank
-    @Schema(description = "전화번호 인증 코드", example = "828282")
+    @Schema(
+            description = "전화번호 인증 코드(6자리 숫자)",
+            example = "828282",
+            pattern = "^\\d{6}$",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
     private String phoneCode;
 }

--- a/src/main/java/goorm/ddok/member/dto/response/ActiveHoursResponse.java
+++ b/src/main/java/goorm/ddok/member/dto/response/ActiveHoursResponse.java
@@ -1,0 +1,13 @@
+package goorm.ddok.member.dto.response;
+
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ActiveHoursResponse {
+    private String start;
+    private String end;
+}

--- a/src/main/java/goorm/ddok/member/dto/response/ActiveHoursResponse.java
+++ b/src/main/java/goorm/ddok/member/dto/response/ActiveHoursResponse.java
@@ -1,5 +1,6 @@
 package goorm.ddok.member.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 
 @Getter
@@ -7,7 +8,35 @@ import lombok.*;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@Schema(
+        name = "ActiveHoursResponse",
+        description = "활동 시간 응답 DTO",
+        example = """
+    {
+      "start": "09",
+      "end": "18"
+    }
+    """
+)
 public class ActiveHoursResponse {
+
+    @Schema(
+            description = "시작 시간 (00~24, 두 자리 문자열)",
+            example = "09",
+            pattern = "^(?:[01]\\d|2[0-4])$",
+            minLength = 2,
+            maxLength = 2,
+            accessMode = Schema.AccessMode.READ_ONLY
+    )
     private String start;
+
+    @Schema(
+            description = "종료 시간 (00~24, 두 자리 문자열)",
+            example = "18",
+            pattern = "^(?:[01]\\d|2[0-4])$",
+            minLength = 2,
+            maxLength = 2,
+            accessMode = Schema.AccessMode.READ_ONLY
+    )
     private String end;
 }

--- a/src/main/java/goorm/ddok/member/dto/response/EmailCheckResponse.java
+++ b/src/main/java/goorm/ddok/member/dto/response/EmailCheckResponse.java
@@ -8,9 +8,21 @@ import lombok.Setter;
 @Getter
 @Setter
 @AllArgsConstructor
-@Schema(description = "이메일 중복 확인 응답 DTO")
+@Schema(
+        name = "EmailCheckResponse",
+        description = "이메일 중복 확인 응답 DTO",
+        example = """
+    {
+      "IsAvailable": true
+    }
+    """
+)
 public class EmailCheckResponse {
 
-    @Schema(description = "가입 가능 여부", example = "true")
+    @Schema(
+            description = "가입 가능 여부",
+            example = "true",
+            accessMode = Schema.AccessMode.READ_ONLY
+    )
     private boolean IsAvailable;
 }

--- a/src/main/java/goorm/ddok/member/dto/response/FindEmailResponse.java
+++ b/src/main/java/goorm/ddok/member/dto/response/FindEmailResponse.java
@@ -2,6 +2,20 @@ package goorm.ddok.member.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
-@Schema(description = "아이디(이메일) 찾기 응답 DTO")
-public record FindEmailResponse(@Schema(description = "이메일", example = "test@test.com") String email) {
-}
+@Schema(
+        name = "FindEmailResponse",
+        description = "아이디(이메일) 찾기 응답 DTO",
+        example = """
+    { "email": "test@test.com" }
+    """
+)
+public record FindEmailResponse(
+        @Schema(
+                description = "이메일",
+                example = "test@test.com",
+                type = "string",
+                format = "email",
+                accessMode = Schema.AccessMode.READ_ONLY
+        )
+        String email
+) {}

--- a/src/main/java/goorm/ddok/member/dto/response/LocationResponse.java
+++ b/src/main/java/goorm/ddok/member/dto/response/LocationResponse.java
@@ -2,9 +2,45 @@ package goorm.ddok.member.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
-@Schema(description = "사용자 위치 정보 응답 DTO")
-public record LocationResponse(@Schema(description = "위도", example = "37.5665") Double latitude,
-                               @Schema(description = "경도", example = "126.9780") Double longitude,
-                               @Schema(description = "주소", example = "서울특별시 강남구 테헤란로 123") String address) {
+@Schema(
+        name = "LocationResponse",
+        description = "사용자 위치 정보 응답 DTO",
+        example = """
+    {
+      "latitude": 37.5665,
+      "longitude": 126.9780,
+      "address": "서울특별시 강남구 테헤란로 123"
+    }
+    """
+)
+public record LocationResponse(
+        @Schema(
+                description = "위도",
+                example = "37.5665",
+                minimum = "-90.0",
+                maximum = "90.0",
+                type = "number",
+                format = "double",
+                accessMode = Schema.AccessMode.READ_ONLY
+        )
+        Double latitude,
 
-}
+        @Schema(
+                description = "경도",
+                example = "126.9780",
+                minimum = "-180.0",
+                maximum = "180.0",
+                type = "number",
+                format = "double",
+                accessMode = Schema.AccessMode.READ_ONLY
+        )
+        Double longitude,
+
+        @Schema(
+                description = "주소",
+                example = "서울특별시 강남구 테헤란로 123",
+                type = "string",
+                accessMode = Schema.AccessMode.READ_ONLY
+        )
+        String address
+) {}

--- a/src/main/java/goorm/ddok/member/dto/response/LocationResponse.java
+++ b/src/main/java/goorm/ddok/member/dto/response/LocationResponse.java
@@ -2,9 +2,9 @@ package goorm.ddok.member.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
-@Schema(description = "사용자 위치 정보")
-public record LocationResponse(@Schema(example = "37.5665") Double latitude,
-                               @Schema(example = "126.9780") Double longitude,
-                               @Schema(example = "서울특별시 강남구 테헤란로…") String address) {
+@Schema(description = "사용자 위치 정보 응답 DTO")
+public record LocationResponse(@Schema(description = "위도", example = "37.5665") Double latitude,
+                               @Schema(description = "경도", example = "126.9780") Double longitude,
+                               @Schema(description = "주소", example = "서울특별시 강남구 테헤란로 123") String address) {
 
 }

--- a/src/main/java/goorm/ddok/member/dto/response/PasswordVerifyUserResponse.java
+++ b/src/main/java/goorm/ddok/member/dto/response/PasswordVerifyUserResponse.java
@@ -6,8 +6,19 @@ import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
-@Schema(description = "비밀번호 찾기 본인 인증 및 reauthToken 발급 응답 DTO")
+@Schema(
+        name = "PasswordVerifyUserResponse",
+        description = "비밀번호 찾기 본인 인증 및 reauthToken 발급 응답 DTO",
+        example = """
+    { "reauthToken": "REAUTH_TOKEN_VALUE" }
+    """
+)
 public class PasswordVerifyUserResponse {
-    @Schema(description = "재인증 토큰", example = "REAUTH_TOKEN_VALUE")
+
+    @Schema(
+            description = "재인증 토큰",
+            example = "REAUTH_TOKEN_VALUE",
+            accessMode = Schema.AccessMode.READ_ONLY
+    )
     private String reauthToken;
 }

--- a/src/main/java/goorm/ddok/member/dto/response/PhoneVerificationResponse.java
+++ b/src/main/java/goorm/ddok/member/dto/response/PhoneVerificationResponse.java
@@ -5,11 +5,22 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
-@Schema
 @AllArgsConstructor
+@Schema(
+        name = "PhoneVerificationResponse",
+        description = "휴대폰 인증 발송 응답 DTO",
+        example = """
+    { "expiresIn": 180 }
+    """
+)
 public class PhoneVerificationResponse {
 
-    @Schema(description = "인증 유효 시간", example =  "180")
+    @Schema(
+            description = "인증 유효 시간(초)",
+            example = "180",
+            type = "integer",
+            format = "int32",
+            accessMode = Schema.AccessMode.READ_ONLY
+    )
     private int expiresIn;
 }
-

--- a/src/main/java/goorm/ddok/member/dto/response/PhoneVerifyCodeResponse.java
+++ b/src/main/java/goorm/ddok/member/dto/response/PhoneVerifyCodeResponse.java
@@ -6,9 +6,19 @@ import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
-@Schema(description = "휴대폰 인증 코드 응답 DTO")
+@Schema(
+        name = "PhoneVerifyCodeResponse",
+        description = "휴대폰 인증 코드 응답 DTO",
+        example = """
+    { "verified": true }
+    """
+)
 public class PhoneVerifyCodeResponse {
 
-    @Schema(description = "인증 확인 여부", example =  "true")
+    @Schema(
+            description = "인증 확인 여부",
+            example = "true",
+            accessMode = Schema.AccessMode.READ_ONLY
+    )
     private boolean verified;
 }

--- a/src/main/java/goorm/ddok/member/dto/response/PreferenceDetailResponse.java
+++ b/src/main/java/goorm/ddok/member/dto/response/PreferenceDetailResponse.java
@@ -1,5 +1,7 @@
 package goorm.ddok.member.dto.response;
 
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 
 import java.time.LocalDate;
@@ -10,12 +12,57 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@Schema(
+        name = "PreferenceDetailResponse",
+        description = "개인화 상세 응답 DTO",
+        example = """
+    {
+      "mainPosition": "백엔드",
+      "subPosition": ["프론트엔드", "데브옵스"],
+      "techStacks": ["Java", "Spring Boot", "React"],
+      "location": { "latitude": 37.5665, "longitude": 126.9780, "address": "서울특별시 강남구 테헤란로 123" },
+      "traits": ["협업", "문제 해결"],
+      "birthDate": "1997-10-10",
+      "activeHours": { "start": "19", "end": "23" }
+    }
+    """
+)
 public class PreferenceDetailResponse {
+
+    @Schema(description = "대표 포지션", example = "백엔드", accessMode = Schema.AccessMode.READ_ONLY)
     private String mainPosition;
+
+    @ArraySchema(
+            minItems = 2,
+            maxItems = 2,
+            arraySchema = @Schema(description = "관심 포지션 (2개)"),
+            schema = @Schema(description = "관심 포지션 항목", example = "프론트엔드")
+    )
+    @Schema(accessMode = Schema.AccessMode.READ_ONLY)
     private List<String> subPosition;
+
+    @ArraySchema(
+            arraySchema = @Schema(description = "기술 스택"),
+            schema = @Schema(description = "기술 스택 항목", example = "Spring Boot")
+    )
+    @Schema(accessMode = Schema.AccessMode.READ_ONLY)
     private List<String> techStacks;
+
+    @Schema(description = "위치 정보", implementation = LocationResponse.class, accessMode = Schema.AccessMode.READ_ONLY)
     private LocationResponse location;
+
+    @ArraySchema(
+            minItems = 1,
+            maxItems = 5,
+            arraySchema = @Schema(description = "특성 리스트 (1~5개)"),
+            schema = @Schema(description = "특성 항목", example = "협업")
+    )
+    @Schema(accessMode = Schema.AccessMode.READ_ONLY)
     private List<String> traits;
+
+    @Schema(description = "생년월일", example = "1997-10-10", type = "string", format = "date", accessMode = Schema.AccessMode.READ_ONLY)
     private LocalDate birthDate;
+
+    @Schema(description = "활동 시간", implementation = ActiveHoursResponse.class, accessMode = Schema.AccessMode.READ_ONLY)
     private ActiveHoursResponse activeHours;
 }

--- a/src/main/java/goorm/ddok/member/dto/response/PreferenceDetailResponse.java
+++ b/src/main/java/goorm/ddok/member/dto/response/PreferenceDetailResponse.java
@@ -1,0 +1,21 @@
+package goorm.ddok.member.dto.response;
+
+import lombok.*;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PreferenceDetailResponse {
+    private String mainPosition;
+    private List<String> subPosition;
+    private List<String> techStacks;
+    private LocationResponse location;
+    private List<String> traits;
+    private LocalDate birthDate;
+    private ActiveHoursResponse activeHours;
+}

--- a/src/main/java/goorm/ddok/member/dto/response/PreferenceResponse.java
+++ b/src/main/java/goorm/ddok/member/dto/response/PreferenceResponse.java
@@ -12,11 +12,11 @@ import java.util.List;
 @Builder
 public class PreferenceResponse {
     private Long id;
+    private String username;
+    private String email;
     private String mainPosition;
-    private List<String> subPosition;
-    private List<String> techStacks;
-    private List<String> traits;
-    private LocalDate birthDate;
-    private LocationResponse location;
-    private ActiveHoursResponse activeHours;
+    private String profileImageUrl;
+    private String nickname;
+    private boolean isPreferences;
+    private PreferenceDetailResponse preferences;
 }

--- a/src/main/java/goorm/ddok/member/dto/response/PreferenceResponse.java
+++ b/src/main/java/goorm/ddok/member/dto/response/PreferenceResponse.java
@@ -1,0 +1,22 @@
+package goorm.ddok.member.dto.response;
+
+import lombok.*;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PreferenceResponse {
+    private Long id;
+    private String mainPosition;
+    private List<String> subPosition;
+    private List<String> techStacks;
+    private List<String> traits;
+    private LocalDate birthDate;
+    private LocationResponse location;
+    private ActiveHoursResponse activeHours;
+}

--- a/src/main/java/goorm/ddok/member/dto/response/PreferenceResponse.java
+++ b/src/main/java/goorm/ddok/member/dto/response/PreferenceResponse.java
@@ -1,22 +1,68 @@
 package goorm.ddok.member.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
-
-import java.time.LocalDate;
-import java.util.List;
 
 @Getter
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@Schema(
+        name = "PreferenceResponse",
+        description = "개인화 설정 응답 DTO",
+        example = """
+    {
+      "id": 123,
+      "username": "dev_yeji",
+      "email": "yeji@example.com",
+      "mainPosition": "백엔드",
+      "profileImageUrl": "https://cdn.example.com/profiles/yeji.png",
+      "nickname": "예지",
+      "isPreferences": true,
+      "preferences": {
+        "mainPosition": "백엔드",
+        "subPosition": ["프론트엔드", "데브옵스"],
+        "techStacks": ["Java", "Spring Boot", "React"],
+        "location": { "latitude": 37.5665, "longitude": 126.9780, "address": "서울특별시 강남구 테헤란로 123" },
+        "traits": ["협업", "문제 해결"],
+        "birthDate": "1997-10-10",
+        "activeHours": { "start": "19", "end": "23" }
+      }
+    }
+    """
+)
 public class PreferenceResponse {
+
+    @Schema(description = "개인화 설정 ID", example = "123", accessMode = Schema.AccessMode.READ_ONLY)
     private Long id;
+
+    @Schema(description = "사용자 아이디(계정명)", example = "dev_yeji", accessMode = Schema.AccessMode.READ_ONLY)
     private String username;
+
+    @Schema(description = "사용자 이메일", example = "yeji@example.com", accessMode = Schema.AccessMode.READ_ONLY)
     private String email;
+
+    @Schema(description = "대표 포지션", example = "백엔드", accessMode = Schema.AccessMode.READ_ONLY)
     private String mainPosition;
+
+    @Schema(description = "프로필 이미지 URL", example = "https://cdn.example.com/profiles/yeji.png", accessMode = Schema.AccessMode.READ_ONLY)
     private String profileImageUrl;
+
+    @Schema(description = "닉네임", example = "예지", accessMode = Schema.AccessMode.READ_ONLY)
     private String nickname;
+
+    @Schema(
+            description = "개인화 설정 여부",
+            example = "true",
+            accessMode = Schema.AccessMode.READ_ONLY
+    )
     private boolean isPreferences;
+
+    @Schema(
+            description = "개인화 상세 정보",
+            implementation = PreferenceDetailResponse.class,
+            accessMode = Schema.AccessMode.READ_ONLY
+    )
     private PreferenceDetailResponse preferences;
 }

--- a/src/main/java/goorm/ddok/member/dto/response/SignInResponse.java
+++ b/src/main/java/goorm/ddok/member/dto/response/SignInResponse.java
@@ -5,13 +5,43 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
-@Schema(description = "로그인 응답 DTO")
+@Schema(
+        name = "SignInResponse",
+        description = "로그인 응답 DTO",
+        example = """
+    {
+      "accessToken": "eyJhbGciOi...",
+      "user": {
+        "id": 1,
+        "username": "홍길동",
+        "email": "test@test.com",
+        "nickname": "고통스러운 개발자",
+        "profileImageUrl": "https://cdn.pixabay.com/photo/2013/07/12/14/15/boy-148071_1280.png",
+        "mainPosition": "백엔드",
+        "IsPreference": true,
+        "location": {
+          "latitude": 37.5665,
+          "longitude": 126.9780,
+          "address": "서울특별시 강남구 테헤란로 123"
+        }
+      }
+    }
+    """
+)
 @AllArgsConstructor
 public class SignInResponse {
 
-    @Schema(description = "Access Token (JWT)", example =  "eyJhbGciOi...")
+    @Schema(
+            description = "Access Token (JWT)",
+            example = "eyJhbGciOi...",
+            accessMode = Schema.AccessMode.READ_ONLY
+    )
     private String accessToken;
 
-    @Schema(description = "로그인 사용자 정보")
+    @Schema(
+            description = "로그인 사용자 정보",
+            implementation = SignInUserResponse.class,
+            accessMode = Schema.AccessMode.READ_ONLY
+    )
     private SignInUserResponse user;
 }

--- a/src/main/java/goorm/ddok/member/dto/response/SignInUserResponse.java
+++ b/src/main/java/goorm/ddok/member/dto/response/SignInUserResponse.java
@@ -1,6 +1,7 @@
 package goorm.ddok.member.dto.response;
 
 import goorm.ddok.member.domain.User;
+import goorm.ddok.member.domain.UserPosition;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
@@ -23,6 +24,9 @@ public class SignInUserResponse {
     @Schema(description = "프로필 이미지 URL", example = "https://cdn.pixabay.com/photo/2013/07/12/14/15/boy-148071_1280.png")
     private final String profileImageUrl;
 
+    @Schema(description = "대표 포지션", example = "백엔드")
+    private final String mainPosition;
+
     @Schema(description = "개인화 설정 여부", example = "true")
     private final boolean IsPreference;
 
@@ -35,7 +39,19 @@ public class SignInUserResponse {
         this.email = user.getEmail();
         this.nickname = user.getNickname();
         this.profileImageUrl = user.getProfileImageUrl();
+        this.mainPosition = getMainPositionFromUser(user);
         this.IsPreference = isPreference;
         this.location = location;
+    }
+
+    private String getMainPositionFromUser(User user) {
+        if (user.getPositions() != null && !user.getPositions().isEmpty()) {
+            return user.getPositions().stream()
+                    .filter(position -> position.getType() == goorm.ddok.member.domain.UserPositionType.PRIMARY)
+                    .findFirst()
+                    .map(UserPosition::getPositionName)
+                    .orElse(null);
+        }
+        return null;
     }
 }

--- a/src/main/java/goorm/ddok/member/dto/response/SignInUserResponse.java
+++ b/src/main/java/goorm/ddok/member/dto/response/SignInUserResponse.java
@@ -6,31 +6,50 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
 @Getter
-@Schema(description = "로그인 사용자 정보 응답 DTO")
+@Schema(
+        name = "SignInUserResponse",
+        description = "로그인 사용자 정보 응답 DTO",
+        example = """
+    {
+      "id": 1,
+      "username": "홍길동",
+      "email": "test@test.com",
+      "nickname": "고통스러운 개발자",
+      "profileImageUrl": "https://cdn.pixabay.com/photo/2013/07/12/14/15/boy-148071_1280.png",
+      "mainPosition": "백엔드",
+      "IsPreference": true,
+      "location": {
+        "latitude": 37.5665,
+        "longitude": 126.9780,
+        "address": "서울특별시 강남구 테헤란로 123"
+      }
+    }
+    """
+)
 public class SignInUserResponse {
 
-    @Schema(description = "사용자 id", example = "1")
+    @Schema(description = "사용자 id", example = "1", accessMode = Schema.AccessMode.READ_ONLY)
     private final Long id;
 
-    @Schema(description = "사용자 실명", example = "홍길동")
+    @Schema(description = "사용자 실명", example = "홍길동", accessMode = Schema.AccessMode.READ_ONLY)
     private final String username;
 
-    @Schema(description = "이메일", example = "test@test.com")
+    @Schema(description = "이메일", example = "test@test.com", accessMode = Schema.AccessMode.READ_ONLY)
     private final String email;
 
-    @Schema(description = "닉네임", example = "고통스러운 개발자")
+    @Schema(description = "닉네임", example = "고통스러운 개발자", accessMode = Schema.AccessMode.READ_ONLY)
     private final String nickname;
 
-    @Schema(description = "프로필 이미지 URL", example = "https://cdn.pixabay.com/photo/2013/07/12/14/15/boy-148071_1280.png")
+    @Schema(description = "프로필 이미지 URL", example = "https://cdn.pixabay.com/photo/2013/07/12/14/15/boy-148071_1280.png", accessMode = Schema.AccessMode.READ_ONLY)
     private final String profileImageUrl;
 
-    @Schema(description = "대표 포지션", example = "백엔드")
+    @Schema(description = "대표 포지션", example = "백엔드", accessMode = Schema.AccessMode.READ_ONLY)
     private final String mainPosition;
 
-    @Schema(description = "개인화 설정 여부", example = "true")
+    @Schema(description = "개인화 설정 여부", example = "true", accessMode = Schema.AccessMode.READ_ONLY)
     private final boolean IsPreference;
 
-    @Schema(description = "사용자 위치 정보")
+    @Schema(description = "사용자 위치 정보", implementation = LocationResponse.class, accessMode = Schema.AccessMode.READ_ONLY)
     private final LocationResponse location;
 
     public SignInUserResponse(User user, boolean isPreference, LocationResponse location) {

--- a/src/main/java/goorm/ddok/member/dto/response/SignUpResponse.java
+++ b/src/main/java/goorm/ddok/member/dto/response/SignUpResponse.java
@@ -6,13 +6,31 @@ import lombok.Getter;
 
 @Getter
 @Builder
-@Schema(description = "회원가입 응답 DTO")
+@Schema(
+        name = "SignUpResponse",
+        description = "회원가입 응답 DTO",
+        example = """
+    {
+      "id": 1,
+      "username": "홍길동"
+    }
+    """
+)
 public class SignUpResponse {
 
-    @Schema(description = "사용자 id", example = "1")
+    @Schema(
+            description = "사용자 id",
+            example = "1",
+            type = "integer",
+            format = "int64",
+            accessMode = Schema.AccessMode.READ_ONLY
+    )
     private Long id;
 
-    @Schema(description = "사용자 실명", example = "홍길동")
+    @Schema(
+            description = "사용자 실명",
+            example = "홍길동",
+            accessMode = Schema.AccessMode.READ_ONLY
+    )
     private String username;
-
 }

--- a/src/main/java/goorm/ddok/member/dto/response/TokenResponse.java
+++ b/src/main/java/goorm/ddok/member/dto/response/TokenResponse.java
@@ -6,7 +6,19 @@ import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
+@Schema(
+        name = "TokenResponse",
+        description = "액세스 토큰 재발급 응답 DTO",
+        example = """
+    { "accessToken": "eyJhbGciOi..." }
+    """
+)
 public class TokenResponse {
-    @Schema(description = "재발급된 토큰", example = "ACCESS_TOKEN_VALUE")
+
+    @Schema(
+            description = "재발급된 액세스 토큰 (JWT)",
+            example = "eyJhbGciOi...",
+            accessMode = Schema.AccessMode.READ_ONLY
+    )
     private String accessToken;
 }

--- a/src/main/java/goorm/ddok/member/repository/TechStackRepository.java
+++ b/src/main/java/goorm/ddok/member/repository/TechStackRepository.java
@@ -3,5 +3,9 @@ package goorm.ddok.member.repository;
 import goorm.ddok.member.domain.TechStack;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface TechStackRepository extends JpaRepository<TechStack, Long> {
+
+    Optional<TechStack> findByName(String techStackName);
 }

--- a/src/main/java/goorm/ddok/member/repository/UserActivityRepository.java
+++ b/src/main/java/goorm/ddok/member/repository/UserActivityRepository.java
@@ -3,5 +3,9 @@ package goorm.ddok.member.repository;
 import goorm.ddok.member.domain.UserActivity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface UserActivityRepository extends JpaRepository<UserActivity, Long> {
+
+    Optional<UserActivity> findByUserId(Long userId);
 }

--- a/src/main/java/goorm/ddok/member/repository/UserActivityRepository.java
+++ b/src/main/java/goorm/ddok/member/repository/UserActivityRepository.java
@@ -1,0 +1,7 @@
+package goorm.ddok.member.repository;
+
+import goorm.ddok.member.domain.UserActivity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserActivityRepository extends JpaRepository<UserActivity, Long> {
+}

--- a/src/main/java/goorm/ddok/member/repository/UserLocationRepository.java
+++ b/src/main/java/goorm/ddok/member/repository/UserLocationRepository.java
@@ -3,5 +3,10 @@ package goorm.ddok.member.repository;
 import goorm.ddok.member.domain.UserLocation;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface UserLocationRepository extends JpaRepository<UserLocation, Long> {
+
+    Optional<UserLocation> findByUserId(Long userId);
+
 }

--- a/src/main/java/goorm/ddok/member/repository/UserLocationRepository.java
+++ b/src/main/java/goorm/ddok/member/repository/UserLocationRepository.java
@@ -1,0 +1,7 @@
+package goorm.ddok.member.repository;
+
+import goorm.ddok.member.domain.UserLocation;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserLocationRepository extends JpaRepository<UserLocation, Long> {
+}

--- a/src/main/java/goorm/ddok/member/repository/UserPositionRepository.java
+++ b/src/main/java/goorm/ddok/member/repository/UserPositionRepository.java
@@ -1,0 +1,7 @@
+package goorm.ddok.member.repository;
+
+import goorm.ddok.member.domain.UserPosition;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserPositionRepository extends JpaRepository<UserPosition, Long> {
+}

--- a/src/main/java/goorm/ddok/member/repository/UserPositionRepository.java
+++ b/src/main/java/goorm/ddok/member/repository/UserPositionRepository.java
@@ -3,5 +3,9 @@ package goorm.ddok.member.repository;
 import goorm.ddok.member.domain.UserPosition;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface UserPositionRepository extends JpaRepository<UserPosition, Long> {
+
+    Optional<UserPosition> findByUserId(Long userId);
 }

--- a/src/main/java/goorm/ddok/member/repository/UserRepository.java
+++ b/src/main/java/goorm/ddok/member/repository/UserRepository.java
@@ -22,4 +22,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     // 이메일 + 이름 회원 조회
     Optional<User> findByEmailAndUsername(String email, String username);
 
+    // 닉네임 중복 확인
+    boolean existsByNickname(String nickname);
 }

--- a/src/main/java/goorm/ddok/member/repository/UserTechStackRepository.java
+++ b/src/main/java/goorm/ddok/member/repository/UserTechStackRepository.java
@@ -1,0 +1,7 @@
+package goorm.ddok.member.repository;
+
+import goorm.ddok.member.domain.UserTechStack;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserTechStackRepository extends JpaRepository<UserTechStack, Long> {
+}

--- a/src/main/java/goorm/ddok/member/repository/UserTechStackRepository.java
+++ b/src/main/java/goorm/ddok/member/repository/UserTechStackRepository.java
@@ -3,5 +3,9 @@ package goorm.ddok.member.repository;
 import goorm.ddok.member.domain.UserTechStack;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface UserTechStackRepository extends JpaRepository<UserTechStack, Long> {
+
+    Optional<UserTechStack> findByUserId(Long userId);
 }

--- a/src/main/java/goorm/ddok/member/repository/UserTraitRepository.java
+++ b/src/main/java/goorm/ddok/member/repository/UserTraitRepository.java
@@ -3,6 +3,10 @@ package goorm.ddok.member.repository;
 import goorm.ddok.member.domain.UserTrait;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface UserTraitRepository extends JpaRepository<UserTrait, Long> {
+
+    Optional<UserTrait> findByUserId(Long userId);
 
 }

--- a/src/main/java/goorm/ddok/member/repository/UserTraitRepository.java
+++ b/src/main/java/goorm/ddok/member/repository/UserTraitRepository.java
@@ -1,0 +1,8 @@
+package goorm.ddok.member.repository;
+
+import goorm.ddok.member.domain.UserTrait;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserTraitRepository extends JpaRepository<UserTrait, Long> {
+
+}

--- a/src/main/java/goorm/ddok/member/service/AuthService.java
+++ b/src/main/java/goorm/ddok/member/service/AuthService.java
@@ -323,6 +323,8 @@ public class AuthService {
             user.setNickname(nickname);
         }
 
+        String profileImageUrl = profileImageService.generateProfileImageUrl(user.getNickname(), 48);
+        user.setProfileImageUrl(profileImageUrl);
 
         return buildPreferenceResponse(user, userLocation, request);
     }

--- a/src/main/java/goorm/ddok/member/service/AuthService.java
+++ b/src/main/java/goorm/ddok/member/service/AuthService.java
@@ -144,7 +144,7 @@ public class AuthService {
         response.addHeader(org.springframework.http.HttpHeaders.SET_COOKIE, cookie.toString());
 
 
-        boolean isPreferences = false;
+        boolean isPreferences = checkIfUserHasPreferences(user);
 
         LocationResponse location = null;
         if (user.getLocation() != null) {
@@ -159,6 +159,14 @@ public class AuthService {
 
         SignInUserResponse userDto = new SignInUserResponse(user, isPreferences, location);
         return new SignInResponse(accessToken, userDto);
+    }
+
+    private boolean checkIfUserHasPreferences(User user) {
+        return user.getLocation() != null &&
+                !user.getPositions().isEmpty() &&
+                !user.getTraits().isEmpty() &&
+                user.getBirthDate() != null &&
+                user.getActivity() != null;
     }
 
     public void signOut(String authorizationHeader, HttpServletResponse response) {
@@ -422,15 +430,26 @@ public class AuthService {
                 .end(request.getActiveHours().getEnd())
                 .build();
 
-        return PreferenceResponse.builder()
-                .id(user.getId())
+        PreferenceDetailResponse preferences = PreferenceDetailResponse.builder()
                 .mainPosition(request.getMainPosition())
                 .subPosition(request.getSubPosition())
                 .techStacks(request.getTechStacks())
+                .location(locationResponse)
                 .traits(request.getTraits())
                 .birthDate(request.getBirthDate())
-                .location(locationResponse)
                 .activeHours(activeHoursResponse)
+                .build();
+
+
+        return PreferenceResponse.builder()
+                .id(user.getId())
+                .username(user.getUsername())
+                .email(user.getEmail())
+                .mainPosition(request.getMainPosition())
+                .profileImageUrl(user.getProfileImageUrl())
+                .nickname(user.getNickname())
+                .isPreferences(true)
+                .preferences(preferences)
                 .build();
     }
 }

--- a/src/main/java/goorm/ddok/member/service/AuthService.java
+++ b/src/main/java/goorm/ddok/member/service/AuthService.java
@@ -5,16 +5,10 @@ import goorm.ddok.global.exception.GlobalException;
 import goorm.ddok.global.security.jwt.JwtTokenProvider;
 import goorm.ddok.global.security.token.ReauthTokenService;
 import goorm.ddok.global.security.token.RefreshTokenService;
-import goorm.ddok.member.domain.AuthType;
-import goorm.ddok.member.domain.PhoneVerification;
-import goorm.ddok.member.domain.User;
+import goorm.ddok.member.domain.*;
 import goorm.ddok.member.dto.request.*;
-import goorm.ddok.member.dto.response.LocationResponse;
-import goorm.ddok.member.dto.response.SignInResponse;
-import goorm.ddok.member.dto.response.SignInUserResponse;
-import goorm.ddok.member.dto.response.SignUpResponse;
-import goorm.ddok.member.repository.PhoneVerificationRepository;
-import goorm.ddok.member.repository.UserRepository;
+import goorm.ddok.member.dto.response.*;
+import goorm.ddok.member.repository.*;
 import goorm.ddok.member.util.NicknameGenerator;
 import io.jsonwebtoken.Claims;
 import jakarta.servlet.http.HttpServletResponse;
@@ -25,6 +19,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.regex.Pattern;
 
 @Service
@@ -33,6 +28,13 @@ public class AuthService {
 
     private final UserRepository userRepository;
     private final PhoneVerificationRepository verificationRepository;
+    private final UserLocationRepository userLocationRepository;
+    private final UserPositionRepository userPositionRepository;
+    private final UserTechStackRepository userTechStackRepository;
+    private final UserActivityRepository userActivityRepository;
+    private final UserTraitRepository userTraitRepository;
+    private final TechStackRepository techStackRepository;
+
     private final PasswordEncoder passwordEncoder;
     private final JwtTokenProvider jwtTokenProvider;
     private final ProfileImageService profileImageService;
@@ -275,4 +277,136 @@ public class AuthService {
         reauthTokenService.delete(email);
     }
 
+    @Transactional
+    public PreferenceResponse createPreference(Long userId, PreferenceRequest request) {
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new GlobalException(ErrorCode.USER_NOT_FOUND));
+
+        // 1. 포지션 정보 저장
+        saveUserPositions(user, request.getMainPosition(), request.getSubPosition());
+
+        // 2. 기술 스택 저장
+        saveUserTechStacks(user, request.getTechStacks());
+
+        // 3. 주 활동 지역 저장
+        UserLocation userLocation = saveUserLocation(user, request.getLocation());
+
+        // 4. 특성(Traits) 저장
+        saveUserTraits(user, request.getTraits());
+
+        // 5. 생년월일 저장
+        user.setBirthDate(request.getBirthDate());
+        userRepository.save(user);
+
+        // 6. 활동 시간 저장
+        saveUserActivity(user, request.getActiveHours());
+
+        return buildPreferenceResponse(user, userLocation, request);
+    }
+
+    private void saveUserPositions(User user, String mainPosition, List<String> subPositions) {
+        UserPosition primaryPosition = UserPosition.primaryOf(user, mainPosition);
+        userPositionRepository.save(primaryPosition);
+
+        for (int i = 0; i < subPositions.size(); i++) {
+            String subPosition = subPositions.get(i);
+            if (subPosition != null && !subPosition.trim().isEmpty()) {
+                UserPosition secondaryPosition = UserPosition.secondaryOf(user, subPosition, (short)(i + 1));
+                userPositionRepository.save(secondaryPosition);
+            }
+        }
+    }
+
+    private void saveUserTechStacks(User user, List<String> techStacks) {
+
+        if (techStacks != null && !techStacks.isEmpty()) {
+            for (String techStackName : techStacks) {
+                if (techStackName != null && !techStackName.trim().isEmpty()) {
+                    TechStack techStack = techStackRepository.findByName(techStackName)
+                            .orElseGet(() -> techStackRepository.save(
+                                    TechStack.builder()
+                                            .name(techStackName.trim())
+                                            .build()
+                            ));
+                    UserTechStack userTechStack = UserTechStack.builder()
+                            .user(user)
+                            .techStack(techStack)
+                            .build();
+                    userTechStackRepository.save(userTechStack);
+                }
+            }
+        }
+    }
+
+    private UserLocation saveUserLocation(User user, LocationRequest locationRequest) {
+        UserLocation userLocation = userLocationRepository.findByUserId(user.getId())
+                .orElse(UserLocation.builder().user(user).build());
+
+        userLocation = userLocation.toBuilder()
+                .roadName(locationRequest.getAddress())
+                .activityLatitude(locationRequest.getLatitude() == null ? null
+                        : new java.math.BigDecimal(String.format(java.util.Locale.US, "%.6f", locationRequest.getLatitude())))
+                .activityLongitude(locationRequest.getLongitude() == null ? null
+                        : new java.math.BigDecimal(String.format(java.util.Locale.US, "%.6f", locationRequest.getLongitude())))
+                .build();
+
+        return userLocationRepository.save(userLocation);
+    }
+
+    private void saveUserTraits(User user, List<String> traits) {
+        if (traits != null && !traits.isEmpty()) {
+            for (String traitName : traits) {
+                if (traitName != null && !traitName.trim().isEmpty()) {
+                    UserTrait userTrait = UserTrait.builder()
+                            .user(user)
+                            .traitName(traitName.trim())
+                            .build();
+                    userTraitRepository.save(userTrait);
+                }
+            }
+        }
+    }
+
+    private void saveUserActivity(User user, ActiveHoursRequest activeHoursRequest) {
+        Integer startHour = Integer.parseInt(activeHoursRequest.getStart());
+        Integer endHour = Integer.parseInt(activeHoursRequest.getEnd());
+
+        UserActivity userActivity = userActivityRepository.findByUserId(user.getId())
+                .orElse(UserActivity.builder().user(user).build());
+
+        userActivity = userActivity.toBuilder()
+                .activityStartTime(startHour)
+                .activityEndTime(endHour)
+                .build();
+
+        userActivityRepository.save(userActivity);
+    }
+
+    private PreferenceResponse buildPreferenceResponse(User user, UserLocation userLocation, PreferenceRequest request) {
+        LocationResponse locationResponse = null;
+        if (userLocation != null) {
+            Double lat = (userLocation.getActivityLatitude() != null)
+                    ? userLocation.getActivityLatitude().doubleValue() : null;
+            Double lon = (userLocation.getActivityLongitude() != null)
+                    ? userLocation.getActivityLongitude().doubleValue() : null;
+            locationResponse = new LocationResponse(lat, lon, userLocation.getRoadName());
+        }
+
+        ActiveHoursResponse activeHoursResponse = ActiveHoursResponse.builder()
+                .start(request.getActiveHours().getStart())
+                .end(request.getActiveHours().getEnd())
+                .build();
+
+        return PreferenceResponse.builder()
+                .id(user.getId())
+                .mainPosition(request.getMainPosition())
+                .subPosition(request.getSubPosition())
+                .techStacks(request.getTechStacks())
+                .traits(request.getTraits())
+                .birthDate(request.getBirthDate())
+                .location(locationResponse)
+                .activeHours(activeHoursResponse)
+                .build();
+    }
 }

--- a/src/main/java/goorm/ddok/member/service/AuthService.java
+++ b/src/main/java/goorm/ddok/member/service/AuthService.java
@@ -302,6 +302,28 @@ public class AuthService {
         // 6. 활동 시간 저장
         saveUserActivity(user, request.getActiveHours());
 
+        if (user.getNickname() == null || user.getNickname().trim().isEmpty()) {
+            String nickname = NicknameGenerator.generate(request.getMainPosition());
+
+            int attempts = 0;
+            while (userRepository.existsByNickname(nickname) && attempts < 10) {
+                nickname = NicknameGenerator.generate(request.getMainPosition());
+                attempts++;
+            }
+
+            if (userRepository.existsByNickname(nickname)) {
+                int suffix = 1;
+                String baseNickname = nickname;
+                while (userRepository.existsByNickname(nickname)) {
+                    nickname = baseNickname + suffix;
+                    suffix++;
+                }
+            }
+
+            user.setNickname(nickname);
+        }
+
+
         return buildPreferenceResponse(user, userLocation, request);
     }
 

--- a/src/main/java/goorm/ddok/member/util/NicknameGenerator.java
+++ b/src/main/java/goorm/ddok/member/util/NicknameGenerator.java
@@ -1,0 +1,26 @@
+package goorm.ddok.member.util;
+
+import java.util.List;
+import java.util.Random;
+
+public class NicknameGenerator {
+
+    private static final List<String> ADJECTIVES = List.of(
+            "겁쟁이인", "고상한", "고통스러운", "과묵한", "광기어린", "괴상한", "권태로운", "귀여운", "귀찮은", "기쁜",
+            "까칠한", "깨끗한", "끈질긴", "날카로운", "노련한", "느긋한", "느린", "달콤한", "따뜻한", "똑똑한",
+            "뜨거운", "멍한", "무뚝뚝한", "무서운", "반짝이는", "밝은", "배고픈", "부끄러운", "분노한", "불안한",
+            "빠른", "산만한", "상냥한", "상쾌한", "서투른", "수줍은", "쉬운", "슬기로운", "시끄러운", "신난",
+            "심란한", "심심한", "쓸쓸한", "애매한", "어두운", "어려운", "엉뚱한", "엉망진창인", "엉큼한", "여유로운",
+            "예민한", "요란한", "요망한", "용감한", "우는", "우아한", "우울한", "웃는", "의젓한", "자신감넘치는",
+            "자유로운", "작은", "장난스런", "재빠른", "정신없는", "정중한", "조급한", "조용한", "졸린", "즐거운",
+            "진지한", "차가운", "침착한", "큰", "평범한", "피곤한", "행복한", "호기심 많은", "홀가분한", "화난",
+            "활기찬", "활발한", "흥분한", "희망찬"
+    );
+
+    private static final Random RANDOM = new Random();
+
+    public static String generate(String mainPosition) {
+        String adj = ADJECTIVES.get(RANDOM.nextInt(ADJECTIVES.size()));
+        return adj + " " + mainPosition.trim();
+    }
+}


### PR DESCRIPTION
## 🔀 PR 제목
- [Refactor] AuthController에 Swagger 스키마/필드 설명 추가
- [Refactor] DTO 전반 Swagger 스키마/예시/배열 제약 보강
- [Feat] 개인화 설정 생성 API 및 도메인/리포지토리 추가

---

## 📌 작업 내용 요약

- Swagger/OpenAPI 문서 대폭 강화
  - AuthController 전 엔드포인트에 @Operation, @ApiResponses, @ExampleObject, @SecurityRequirement, @Parameter(in = HEADER/COOKIE) 추가
  - 요청/응답 본문 예시 JSON 및 에러 예시(ErrorCode 기반) 제공
  - 헤더(Authorization: Bearer ...)와 쿠키(refreshToken) 파라미터 명세화

- DTO Swagger 스키마/설명 개선

- 개인화 설정 기능
  - createPreference API 추가: 포지션/기술스택/위치/특성/생년월일/활동시간 등록
  - 닉네임 자동 생성 + 중복 회피 로직 추가
  - 프로필 이미지 URL 생성 기능 추가

- 도메인/저장 필드 정리
  - UserActivity 빌더 toBuilder=true
  - 활동 시간 저장 타입을 Instant → Integer로 정리(서버 내부 표현 정합성)



---

## ✅ 체크리스트
PR을 올리기 전에 아래 항목을 확인했나요?

- [ ] 기능 요구사항을 모두 구현했나요?
- [ ] 로컬에서 기능을 직접 테스트했나요?
- [ ] 코드 컨벤션 및 스타일을 지켰나요?
- [ ] 관련된 이슈에 연결했나요?

---

## 🔗 관련 이슈

- Closes #8 
- Related to #6 
---

## 📎 기타 참고 사항

- API 명세 변경: Swagger 문서에 예시/에러/보안 스키마/쿠키·헤더 파라미터가 추가되었습니다. 프론트에서 Swagger UI 기반 연동 시 가이드가 크게 개선됩니다.
