### PR TITLE
[Feature] 기술 스택 검색 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -88,6 +88,11 @@ dependencies {
 
     //카카오 로그인 관련
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+
+    // Elasticsearch
+    implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch'
+    implementation 'co.elastic.clients:elasticsearch-java:8.11.0'
+
 }
 
 tasks.named('test') {

--- a/docker-compose-template.yml
+++ b/docker-compose-template.yml
@@ -7,3 +7,32 @@ services:
       - "6379:6379"
     restart: unless-stopped
     command: ["redis-server", "--requirepass", "${REDIS_PASSWORD}"]
+
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.15.0
+    container_name: elasticsearch
+    environment:
+      - discovery.type=single-node
+      - xpack.security.enabled=false
+      - ES_JAVA_OPTS=-Xms1g -Xmx1g
+    ports:
+      - "9200:9200"
+      - "9300:9300"
+    volumes:
+      - es-data:/usr/share/elasticsearch/data
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+      nofile:
+        soft: 65536
+        hard: 65536
+    healthcheck:
+      test: [ "CMD", "curl", "-f", "http://localhost:9200/_cluster/health" ]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+    restart: unless-stopped
+
+volumes:
+  es-data:

--- a/docker-compose-template.yml
+++ b/docker-compose-template.yml
@@ -34,5 +34,27 @@ services:
       retries: 12
     restart: unless-stopped
 
+  kibana:
+    image: docker.elastic.co/kibana/kibana:8.15.0
+    container_name: kibana
+    environment:
+      - ELASTICSEARCH_HOSTS=http://elasticsearch:9200
+      - SERVER_HOST=0.0.0.0
+      - SERVER_PUBLICBASEURL=http://localhost:5601
+      - XPACK_SECURITY_ENABLED=false
+      # (메모리 부족하면 아래 주석 해제)
+      # - NODE_OPTIONS=--max-old-space-size=1024
+    ports:
+      - "5601:5601"
+    depends_on:
+      elasticsearch:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:5601/api/status"]
+      interval: 10s
+      timeout: 5s
+      retries: 30
+    restart: unless-stopped
+
 volumes:
   es-data:

--- a/src/main/java/goorm/ddok/member/controller/TechStackSearchController.java
+++ b/src/main/java/goorm/ddok/member/controller/TechStackSearchController.java
@@ -1,0 +1,78 @@
+package goorm.ddok.member.controller;
+
+import goorm.ddok.global.response.ApiResponseDto;
+import goorm.ddok.member.dto.response.TechStackResponse;
+import goorm.ddok.member.service.TechStackSearchService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Size;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/auth")
+@Validated
+public class TechStackSearchController {
+
+    private final TechStackSearchService techStackSearchService;
+
+    @Operation(
+            summary = "기술 스택 검색",
+            description = "키워드로 기술 스택을 검색합니다. (as-you-type + 오타 허용)",
+            security = @SecurityRequirement(name = "Authorization")
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "기술 스택 검색 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    name = "Spring 검색 결과",
+                                    value = """
+                                    {
+                                      "status": 200,
+                                      "message": "기술 스택 검색에 성공하였습니다.",
+                                      "data": {
+                                        "techStacks": [
+                                          "Spring Boot",
+                                          "Spring Data JPA",
+                                          "Spring Security"
+                                        ]
+                                      }
+                                    }
+                                    """
+                            )
+                    )
+            ),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자")
+    })
+    @GetMapping("/stacks")
+    public ResponseEntity<ApiResponseDto<TechStackResponse>> searchTechStacks(
+            @Parameter(description = "검색할 기술 스택 키워드(1~50자)", example = "spring")
+            @RequestParam(required = false)
+            @Size(min = 1, max = 50, message = "keyword는 1~50자여야 합니다.")
+            String keyword,
+
+            @Parameter(description = "최대 반환 개수(1~50, 기본 10)", example = "10")
+            @RequestParam(defaultValue = "10")
+            @Min(1) @Max(50)
+            Integer size
+    ) {
+        TechStackResponse response = techStackSearchService.searchTechStacks(keyword);
+        return ResponseEntity.ok(ApiResponseDto.of(200, "기술 스택 검색에 성공하였습니다.", response));
+    }
+}

--- a/src/main/java/goorm/ddok/member/controller/TechStackSearchController.java
+++ b/src/main/java/goorm/ddok/member/controller/TechStackSearchController.java
@@ -65,13 +65,15 @@ public class TechStackSearchController {
             @Parameter(description = "검색할 기술 스택 키워드(1~50자)", example = "spring")
             @RequestParam(required = false)
             @Size(min = 1, max = 50, message = "keyword는 1~50자여야 합니다.")
-            String keyword,
-
-            @Parameter(description = "최대 반환 개수(1~50, 기본 10)", example = "10")
-            @RequestParam(defaultValue = "10")
-            @Min(1) @Max(50)
-            Integer size
+            String keyword
     ) {
+        String q = keyword == null ? "" : keyword.strip();
+        int len = q.codePointCount(0, q.length());  // 유니코드 안전 길이
+        if (len < 1 || len > 50) {
+            return ResponseEntity.badRequest()
+                    .body(ApiResponseDto.of(400, "keyword는 1~50자여야 합니다.", null));
+        }
+
         TechStackResponse response = techStackSearchService.searchTechStacks(keyword);
         return ResponseEntity.ok(ApiResponseDto.of(200, "기술 스택 검색에 성공하였습니다.", response));
     }

--- a/src/main/java/goorm/ddok/member/controller/TechStackSearchController.java
+++ b/src/main/java/goorm/ddok/member/controller/TechStackSearchController.java
@@ -10,8 +10,6 @@ import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
-import jakarta.validation.constraints.Max;
-import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.Size;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/goorm/ddok/member/dto/response/TechStackResponse.java
+++ b/src/main/java/goorm/ddok/member/dto/response/TechStackResponse.java
@@ -1,0 +1,18 @@
+package goorm.ddok.member.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Schema(description = "기술 스택 검색 응답 DTO")
+public class TechStackResponse {
+
+    @Schema(description = "검색된 기술 스택 리스트", example = "[\"SpringBoot\", \"SpringDataJPA\", \"SpringSecurity\"]")
+    private List<String> techStacks;
+}

--- a/src/main/java/goorm/ddok/member/repository/TechStackRepository.java
+++ b/src/main/java/goorm/ddok/member/repository/TechStackRepository.java
@@ -1,11 +1,17 @@
 package goorm.ddok.member.repository;
 
 import goorm.ddok.member.domain.TechStack;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface TechStackRepository extends JpaRepository<TechStack, Long> {
 
     Optional<TechStack> findByName(String techStackName);
+
+    @Query("select t.name from TechStack t where lower(t.name) like lower(concat('%', :keyword, '%'))")
+    List<String> findNamesByKeyword(String keyword, Pageable pageable);
 }

--- a/src/main/java/goorm/ddok/member/search/TechStackDocument.java
+++ b/src/main/java/goorm/ddok/member/search/TechStackDocument.java
@@ -1,0 +1,44 @@
+package goorm.ddok.member.search;
+
+import lombok.*;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.elasticsearch.annotations.CompletionField;
+import org.springframework.data.elasticsearch.annotations.Document;
+import org.springframework.data.elasticsearch.annotations.Field;
+import org.springframework.data.elasticsearch.annotations.FieldType;
+import org.springframework.data.elasticsearch.core.suggest.Completion;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Document(indexName = "tech_stacks")
+public class TechStackDocument {
+
+    @Id
+    private String id;
+
+    /** 검색 표기명 */
+    @Field(type = FieldType.Text, analyzer = "tech_index_analyzer", searchAnalyzer = "tech_search_analyzer")
+    private String name;
+
+    /** 정렬/중복제거용 keyword 서브필드가 매핑에 존재( name.kw )한다는 가정 */
+    // 굳이 필드로 빼지 않아도 되지만, 필요시 getter 용도로 둬도 무방
+
+    /** 공백 제거 + lowercase + asciifolding 단일 토큰 검색용 */
+    @Field(name = "name.norm", type = FieldType.Text, analyzer = "tech_keyword_like_analyzer", searchAnalyzer = "tech_keyword_like_analyzer")
+    private String nameNorm; // 실제 인덱싱 시 동기화 용도(선택). 없더라도 검색은 필드 경로로 접근 가능.
+
+    /** 카테고리(백엔드/프론트/데브옵스 등) */
+    @Field(type = FieldType.Keyword)
+    private String category;
+
+    /** 인기도 */
+    @Field(type = FieldType.Integer)
+    private Integer popularity;
+
+    /** 자동완성 추천(completion) */
+    @CompletionField(maxInputLength = 100)
+    private Completion suggest;
+}

--- a/src/main/java/goorm/ddok/member/search/TechStackDocument.java
+++ b/src/main/java/goorm/ddok/member/search/TechStackDocument.java
@@ -23,9 +23,6 @@ public class TechStackDocument {
     @Field(type = FieldType.Text, analyzer = "tech_index_analyzer", searchAnalyzer = "tech_search_analyzer")
     private String name;
 
-    /** 정렬/중복제거용 keyword 서브필드가 매핑에 존재( name.kw )한다는 가정 */
-    // 굳이 필드로 빼지 않아도 되지만, 필요시 getter 용도로 둬도 무방
-
     /** 공백 제거 + lowercase + asciifolding 단일 토큰 검색용 */
     @Field(name = "name.norm", type = FieldType.Text, analyzer = "tech_keyword_like_analyzer", searchAnalyzer = "tech_keyword_like_analyzer")
     private String nameNorm; // 실제 인덱싱 시 동기화 용도(선택). 없더라도 검색은 필드 경로로 접근 가능.

--- a/src/main/java/goorm/ddok/member/search/TechStackIndexInitializer.java
+++ b/src/main/java/goorm/ddok/member/search/TechStackIndexInitializer.java
@@ -1,0 +1,107 @@
+package goorm.ddok.member.search;
+
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+import org.springframework.data.elasticsearch.core.IndexOperations;
+import org.springframework.data.elasticsearch.core.document.Document;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class TechStackIndexInitializer {
+    private final ElasticsearchOperations operations;
+
+    @PostConstruct
+    public void init() {
+        IndexOperations io = operations.indexOps(TechStackDocument.class);
+        if (!io.exists()) {
+            createIndexWithSafeSettings(io);
+        }
+    }
+
+    private void createIndexWithSafeSettings(IndexOperations io) {
+        Map<String, Object> settings = Map.of(
+                "number_of_shards", 1,
+                "number_of_replicas", 0,
+                "analysis", Map.of(
+                        "char_filter", Map.of(
+                                "remove_spaces_cf", Map.of(
+                                        "type", "pattern_replace",
+                                        "pattern", "\\s+",
+                                        "replacement", ""
+                                )
+                        ),
+                        "filter", Map.of(
+                                "tech_lc", Map.of("type", "lowercase"),
+                                "tech_ascii", Map.of("type", "asciifolding")
+                        ),
+                        "normalizer", Map.of(
+                                "tech_normalizer", Map.of(
+                                        "type", "custom",
+                                        "filter", List.of("tech_lc", "tech_ascii") // ✅ char_filter 넣지 않음
+                                )
+                        ),
+                        "tokenizer", Map.of(
+                                "tech_edge_ngram", Map.of(
+                                        "type", "edge_ngram",
+                                        "min_gram", 1,
+                                        "max_gram", 20,
+                                        "token_chars", List.of("letter", "digit")
+                                )
+                        ),
+                        "analyzer", Map.of(
+                                "tech_index_analyzer", Map.of(
+                                        "type", "custom",
+                                        "tokenizer", "tech_edge_ngram",
+                                        "filter", List.of("lowercase", "asciifolding")
+                                ),
+                                "tech_search_analyzer", Map.of(
+                                        "type", "custom",
+                                        "tokenizer", "standard",
+                                        "filter", List.of("lowercase", "asciifolding")
+                                ),
+                                "tech_keyword_like_analyzer", Map.of(
+                                        "type", "custom",
+                                        "tokenizer", "keyword",
+                                        "char_filter", List.of("remove_spaces_cf"),
+                                        "filter", List.of("lowercase", "asciifolding")
+                                )
+                        )
+                )
+        );
+
+        Map<String, Object> mappings = Map.of(
+                "properties", Map.of(
+                        "name", Map.of(
+                                "type", "text",
+                                "analyzer", "tech_index_analyzer",
+                                "search_analyzer", "tech_search_analyzer",
+                                "fields", Map.of(
+                                        "kw", Map.of(
+                                                "type", "keyword",
+                                                "normalizer", "tech_normalizer"
+                                        ),
+                                        "norm", Map.of(
+                                                "type", "text",
+                                                "analyzer", "tech_keyword_like_analyzer",
+                                                "search_analyzer", "tech_keyword_like_analyzer"
+                                        ),
+                                        "suggest", Map.of("type", "completion")
+                                )
+                        ),
+                        "category", Map.of("type", "keyword"),
+                        "popularity", Map.of("type", "integer")
+                )
+        );
+
+        Document settingsDoc = Document.from(settings);
+        Document mappingsDoc = Document.from(mappings);
+
+        io.create(settingsDoc);
+        io.putMapping(mappingsDoc);
+    }
+}

--- a/src/main/java/goorm/ddok/member/search/TechStackIndexer.java
+++ b/src/main/java/goorm/ddok/member/search/TechStackIndexer.java
@@ -1,0 +1,46 @@
+package goorm.ddok.member.search;
+
+import goorm.ddok.member.domain.TechStack;
+import goorm.ddok.member.repository.TechStackRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class TechStackIndexer implements ApplicationRunner {
+
+    private final TechStackRepository jpaRepo;
+    private final TechStackSearchRepository esRepo;
+
+    @Override
+    public void run(ApplicationArguments args) {
+        long esCount = esRepo.count();
+        if (esCount > 0) {
+            log.info("[TechStackIndexer] ES already has {} docs. Skip bootstrap.", esCount);
+            return;
+        }
+
+        List<TechStack> all = jpaRepo.findAll();
+        if (all.isEmpty()) {
+            log.info("[TechStackIndexer] No rows in DB. Nothing to index.");
+            return;
+        }
+
+        List<TechStackDocument> docs = new ArrayList<>(all.size());
+        for (TechStack t : all) {
+            docs.add(TechStackDocument.builder()
+                    .id(String.valueOf(t.getId()))
+                    .name(t.getName())
+                    .build());
+        }
+        esRepo.saveAll(docs);
+        log.info("[TechStackIndexer] Indexed {} tech stacks into Elasticsearch.", docs.size());
+    }
+}

--- a/src/main/java/goorm/ddok/member/search/TechStackSearchRepository.java
+++ b/src/main/java/goorm/ddok/member/search/TechStackSearchRepository.java
@@ -1,0 +1,9 @@
+package goorm.ddok.member.search;
+
+import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
+
+import java.util.List;
+
+public interface TechStackSearchRepository extends ElasticsearchRepository<TechStackDocument, String> {
+    List<TechStackDocument> findByNameContainingIgnoreCase(String keyword);
+}

--- a/src/main/java/goorm/ddok/member/service/TechStackSearchService.java
+++ b/src/main/java/goorm/ddok/member/service/TechStackSearchService.java
@@ -1,20 +1,17 @@
 package goorm.ddok.member.service;
 
-import co.elastic.clients.elasticsearch._types.SortOrder;
 import co.elastic.clients.elasticsearch._types.query_dsl.QueryBuilders;
 import goorm.ddok.member.dto.response.TechStackResponse;
 import goorm.ddok.member.repository.TechStackRepository;
 import goorm.ddok.member.search.TechStackDocument;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataAccessResourceFailureException;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.elasticsearch.client.elc.NativeQuery;
 import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
 import org.springframework.data.elasticsearch.core.SearchHit;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/goorm/ddok/member/service/TechStackSearchService.java
+++ b/src/main/java/goorm/ddok/member/service/TechStackSearchService.java
@@ -1,0 +1,104 @@
+package goorm.ddok.member.service;
+
+import co.elastic.clients.elasticsearch._types.SortOrder;
+import co.elastic.clients.elasticsearch._types.query_dsl.QueryBuilders;
+import goorm.ddok.member.dto.response.TechStackResponse;
+import goorm.ddok.member.repository.TechStackRepository;
+import goorm.ddok.member.search.TechStackDocument;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataAccessResourceFailureException;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.elasticsearch.client.elc.NativeQuery;
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+import org.springframework.data.elasticsearch.core.SearchHit;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class TechStackSearchService {
+
+    private final ElasticsearchOperations operations;
+    private final TechStackRepository jpaRepo;
+
+    public TechStackResponse searchTechStacks(String keyword) {
+        if (keyword == null || keyword.isBlank()) {
+            return new TechStackResponse(List.of());
+        }
+
+        String original = keyword.trim();
+        String normalized = normalizeKeyword(keyword);
+
+        NativeQuery query = buildOptimizedQuery(original, normalized);
+
+        try {
+            var hits = operations.search(query, TechStackDocument.class);
+
+            List<String> names = hits.getSearchHits().stream()
+                    .map(SearchHit::getContent)
+                    .map(TechStackDocument::getName)
+                    .filter(s -> s != null && !s.isBlank())
+                    .distinct()
+                    .limit(10)
+                    .toList();
+
+            if (names.isEmpty()) {
+                names = jpaRepo.findNamesByKeyword(original, org.springframework.data.domain.PageRequest.of(0, 10));
+            }
+            return new TechStackResponse(names);
+        } catch (DataAccessResourceFailureException e) {
+            // ES down 등 연결 문제
+            return new TechStackResponse(List.of());
+        } catch (org.springframework.data.elasticsearch.UncategorizedElasticsearchException |
+                 co.elastic.clients.elasticsearch._types.ElasticsearchException e) {
+            // 매핑/필드 오류 포함 → 폴백
+            return new TechStackResponse(List.of());
+        }
+    }
+
+    private String normalizeKeyword(String keyword) {
+        return keyword.toLowerCase()
+                .replaceAll("\\s+", "")
+                .replaceAll("[^a-z0-9]", "");
+    }
+
+    private NativeQuery buildOptimizedQuery(String original, String normalized) {
+        var bool = QueryBuilders.bool()
+                // 정확매치(공백 제거 단일 토큰)
+                .should(QueryBuilders.term()
+                        .field("name.norm")
+                        .value(normalized)
+                        .boost(10.0f)
+                        .build()._toQuery())
+                // 접두사
+                .should(QueryBuilders.prefix()
+                        .field("name.norm")
+                        .value(normalized)
+                        .boost(5.0f)
+                        .build()._toQuery())
+                // 일반 매치
+                .should(QueryBuilders.match()
+                        .field("name")
+                        .query(original)
+                        .boost(3.0f)
+                        .build()._toQuery())
+                // 오타 허용
+                .should(QueryBuilders.match()
+                        .field("name")
+                        .query(original)
+                        .fuzziness("AUTO")
+                        .boost(1.0f)
+                        .build()._toQuery())
+                .minimumShouldMatch("1")
+                .build();
+
+        return NativeQuery.builder()
+                .withQuery(bool._toQuery())
+                .withSort(s -> s.score(sc -> sc.order(SortOrder.Desc)))
+                .withSort(s -> s.field(f -> f.field("name.kw").order(SortOrder.Asc))) // 없으면 자동 무시 아님 → 인덱스 재생성 필요
+                .withPageable(PageRequest.of(0, 20)) // 여유분 확보 후 distinct/limit(10)
+                .build();
+    }
+}

--- a/start-dev.sh
+++ b/start-dev.sh
@@ -112,64 +112,90 @@ create_or_recreate_techstacks_index() {
       "filter": {
         "tech_lc": { "type": "lowercase" },
         "tech_ascii": { "type": "asciifolding" },
+
+        "edge_ngram_filter": { "type": "edge_ngram", "min_gram": 1, "max_gram": 20 },
+
+        "ko_en_syn_index": {
+          "type": "synonym",
+          "expand": true,
+          "synonyms": [
+            "spring boot, springboot, 스프링부트, 스프링 부트",
+            "spring data jpa, springdatajpa, 스프링데이터 jpa, 스프링 데이터 jpa, 스프링데이터 제이피에이, 스프링 데이터 제이피에이, jpa, 제이피에이",
+            "spring security, 스프링시큐리티, 스프링 시큐리티",
+            "java, 자바",
+            "kotlin, 코틀린",
+            "python, 파이썬",
+            "node, node js, nodejs, node.js, 노드, 노드제이에스",
+            "express, 익스프레스, 엑스프레스",
+            "typescript, ts, 타입스크립트",
+            "react, 리액트",
+            "next, next js, nextjs, next.js, 넥스트, 넥스트 js",
+            "vue, vue js, vuejs, vue.js, 뷰, 뷰 js",
+            "angular, 앵귤러",
+            "mysql, my sql, 마이에스큐엘",
+            "postgresql, postgres, psql, 포스트그레스, 포스트그레스큐엘",
+            "redis, 레디스",
+            "mongodb, mongo, 몽고디비, 몽고 db",
+            "docker, 도커",
+            "kubernetes, k8s, 쿠버네티스",
+            "aws, 아마존웹서비스, 아마존 웹 서비스",
+            "github actions, gh actions, 깃허브액션, 깃허브 액션, 깃헙액션, 깃헙 액션"
+          ]
+        },
+
         "ko_en_syn": {
           "type": "synonym_graph",
           "synonyms": [
-            "자바, java",
-            "자바스크립트, javascript, js",
-            "스프링, spring",
-            "스프링부트, spring boot, springboot",
-            "스프링시큐리티, spring security",
-            "도커, docker",
-            "쿠버네티스, kubernetes, k8s",
-            "레디스, redis",
-            "몽고디비, mongodb, mongo",
-            "포스트그레스, postgresql, postgres, psql",
-            "타입스크립트, typescript, ts",
-            "노드, node, node js, nodejs",
-            "익스프레스, express",
-            "리액트, react",
-            "뷰, vue, vue js, vuejs",
-            "앵귤러, angular",
-            "깃허브액션, github actions, gh actions",
-            "스프링데이터jpa, spring data jpa, springdatajpa"
+            "spring boot, springboot, 스프링부트, 스프링 부트",
+            "spring data jpa, springdatajpa, 스프링데이터 jpa, 스프링 데이터 jpa, 스프링데이터 제이피에이, 스프링 데이터 제이피에이, jpa, 제이피에이",
+            "spring security, 스프링시큐리티, 스프링 시큐리티",
+            "java, 자바",
+            "kotlin, 코틀린",
+            "python, 파이썬",
+            "node, node js, nodejs, node.js, 노드, 노드제이에스",
+            "express, 익스프레스, 엑스프레스",
+            "typescript, ts, 타입스크립트",
+            "react, 리액트",
+            "next, next js, nextjs, next.js, 넥스트, 넥스트 js",
+            "vue, vue js, vuejs, vue.js, 뷰, 뷰 js",
+            "angular, 앵귤러",
+            "mysql, my sql, 마이에스큐엘",
+            "postgresql, postgres, psql, 포스트그레스, 포스트그레스큐엘",
+            "redis, 레디스",
+            "mongodb, mongo, 몽고디비, 몽고 db",
+            "docker, 도커",
+            "kubernetes, k8s, 쿠버네티스",
+            "aws, 아마존웹서비스, 아마존 웹 서비스",
+            "github actions, gh actions, 깃허브액션, 깃허브 액션, 깃헙액션, 깃헙 액션"
           ]
         }
       },
+
       "normalizer": {
-        "tech_normalizer": {
-          "type": "custom",
-          "filter": ["tech_lc", "tech_ascii"]
-        }
+        "tech_normalizer": { "type": "custom", "filter": ["tech_lc", "tech_ascii"] }
       },
-      "tokenizer": {
-        "tech_edge_ngram": {
-          "type": "edge_ngram",
-          "min_gram": 1,
-          "max_gram": 20,
-          "token_chars": ["letter","digit"]
-        }
-      },
+
       "analyzer": {
         "tech_index_analyzer": {
           "type": "custom",
-          "tokenizer": "tech_edge_ngram",
-          "filter": ["lowercase","asciifolding"]
+          "tokenizer": "standard",
+          "filter": [ "tech_lc", "tech_ascii", "ko_en_syn_index", "edge_ngram_filter" ]
         },
         "tech_search_analyzer": {
           "type": "custom",
           "tokenizer": "standard",
-          "filter": ["lowercase","asciifolding","ko_en_syn"]
+          "filter": [ "tech_lc", "tech_ascii", "ko_en_syn" ]
         },
         "tech_keyword_like_analyzer": {
           "type": "custom",
           "tokenizer": "keyword",
           "char_filter": ["remove_spaces_cf"],
-          "filter": ["lowercase","asciifolding"]
+          "filter": [ "tech_lc", "tech_ascii" ]
         }
       }
     }
   },
+
   "mappings": {
     "properties": {
       "name": {
@@ -187,8 +213,6 @@ create_or_recreate_techstacks_index() {
     }
   }
 }
-
-
 JSON
 
   curl -s -XPUT "http://localhost:9200/tech_stacks" \

--- a/start-dev.sh
+++ b/start-dev.sh
@@ -19,12 +19,19 @@ fi
 
 echo "🧱 Redis 컨테이너 실행 중..."
 docker-compose up -d redis
-
 if [ $? -ne 0 ]; then
   echo "❌ Redis 실행 실패. 도커 설치 상태나 포트를 확인하세요."
   exit 1
 fi
-
 echo "✅ Redis 실행 완료."
+
+echo "🔎 Elasticsearch 컨테이너 실행 중..."
+docker-compose up -d elasticsearch
+if [ $? -ne 0 ]; then
+  echo "❌ Elasticsearch 실행 실패. 도커 설치 상태나 포트를 확인하세요."
+  exit 1
+fi
+echo "✅ Elasticsearch 실행 완료."
+
 echo "🚀 Spring Boot 서버 실행 중..."
 ./gradlew bootRun

--- a/start-dev.sh
+++ b/start-dev.sh
@@ -1,5 +1,13 @@
 set -e
 
+# =========================
+# 환경 변수 (옵션)
+# =========================
+# Kibana도 같이 올릴지 여부 (template에 kibana 서비스가 없으면 자동 스킵)
+START_KIBANA="${START_KIBANA:-true}"
+# 기존 tech_stacks 인덱스를 강제 재생성할지 여부 (true면 삭제 후 재생성)
+FORCE_RECREATE_TECHSTACKS="${FORCE_RECREATE_TECHSTACKS:-false}"
+
 # 0. application-env.properties 경로 변수
 ENV_FILE="src/main/resources/application-env.properties"
 
@@ -17,21 +25,191 @@ else
   echo "spring.data.redis.password=$REDIS_PASSWORD" >> "$ENV_FILE"
 fi
 
+# -------------------------
+# 유틸 함수
+# -------------------------
+wait_for_es() {
+  echo "🔎 Elasticsearch health 대기 중..."
+  for i in {1..60}; do
+    # 200 응답 여부
+    if curl -sSf "http://localhost:9200/" >/dev/null 2>&1; then
+      STATUS=$(curl -s "http://localhost:9200/_cluster/health" | sed -n 's/.*"status":"\([^"]*\)".*/\1/p')
+      if [ "$STATUS" = "green" ] || [ "$STATUS" = "yellow" ]; then
+        echo "✅ Elasticsearch health: $STATUS"
+        return 0
+      fi
+      echo "⏳ Elasticsearch status: ${STATUS:-unknown} (재시도)"
+    else
+      echo "⏳ Elasticsearch 응답 대기..."
+    fi
+    sleep 2
+  done
+  echo "❌ Elasticsearch health 확인 실패"
+  return 1
+}
+
+wait_for_kibana() {
+  echo "🔎 Kibana status 대기 중..."
+  for i in $(seq 1 60); do
+    # /api/status 호출 (200/JSON이면 파일 저장), 실패해도 계속
+    CODE=$(curl -s -o /tmp/kbn_status.json -w '%{http_code}' http://localhost:5601/api/status || echo 000)
+
+    if [ "$CODE" = "200" ]; then
+      # Kibana 8.x: overall.level.id 가 'available' 이면 준비 완료
+      if grep -q '"overall"' /tmp/kbn_status.json && grep -q '"id":"available"' /tmp/kbn_status.json; then
+        echo "✅ Kibana: available"
+        return 0
+      fi
+      # 구버전/다른 포맷 대비: 본문에 'available' 또는 'green' 이라는 단어가 있으면 통과
+      if grep -q '"available"' /tmp/kbn_status.json || grep -q '"green"' /tmp/kbn_status.json; then
+        echo "✅ Kibana: available"
+        return 0
+      fi
+      echo "⏳ Kibana 응답 200 (아직 준비 중)"
+    else
+      # 보안/리다이렉트 등으로 /api/status가 안 열려도, 루트가 200이면 UI는 뜬 것
+      ROOT_CODE=$(curl -s -o /dev/null -w '%{http_code}' http://localhost:5601/ || echo 000)
+      if [ "$ROOT_CODE" = "200" ]; then
+        echo "✅ Kibana UI 응답 200 → 진행"
+        return 0
+      fi
+      echo "⏳ Kibana 응답 코드: $CODE"
+    fi
+
+    sleep 2
+  done
+  echo "⚠️ Kibana 상태 확인 실패(계속 진행)"
+  return 0
+}
+
+create_or_recreate_techstacks_index() {
+  # 인덱스 존재 확인
+  HTTP_CODE=$(curl -s -o /dev/null -w '%{http_code}' "http://localhost:9200/tech_stacks")
+  if [ "$HTTP_CODE" = "200" ]; then
+    if [ "$FORCE_RECREATE_TECHSTACKS" = "true" ]; then
+      echo "🧨 기존 tech_stacks 인덱스 삭제(강제 재생성 모드)"
+      curl -s -XDELETE "http://localhost:9200/tech_stacks" >/dev/null
+    else
+      echo "ℹ️ tech_stacks 인덱스가 이미 존재합니다 (재생성 안 함)"
+      return 0
+    fi
+  fi
+
+  echo "🧱 tech_stacks 인덱스 생성(안전한 분석기/매핑)"
+  cat > /tmp/tech_stacks_mapping.json <<'JSON'
+{
+  "settings": {
+    "number_of_shards": 1,
+    "number_of_replicas": 0,
+    "analysis": {
+      "char_filter": {
+        "remove_spaces_cf": {
+          "type": "pattern_replace",
+          "pattern": "\\s+",
+          "replacement": ""
+        }
+      },
+      "filter": {
+        "tech_lc": { "type": "lowercase" },
+        "tech_ascii": { "type": "asciifolding" }
+      },
+      "normalizer": {
+        "tech_normalizer": {
+          "type": "custom",
+          "filter": ["tech_lc", "tech_ascii"]
+        }
+      },
+      "tokenizer": {
+        "tech_edge_ngram": {
+          "type": "edge_ngram",
+          "min_gram": 1,
+          "max_gram": 20,
+          "token_chars": ["letter", "digit"]
+        }
+      },
+      "analyzer": {
+        "tech_index_analyzer": {
+          "type": "custom",
+          "tokenizer": "tech_edge_ngram",
+          "filter": ["lowercase", "asciifolding"]
+        },
+        "tech_search_analyzer": {
+          "type": "custom",
+          "tokenizer": "standard",
+          "filter": ["lowercase", "asciifolding"]
+        },
+        "tech_keyword_like_analyzer": {
+          "type": "custom",
+          "tokenizer": "keyword",
+          "char_filter": ["remove_spaces_cf"],
+          "filter": ["lowercase", "asciifolding"]
+        }
+      }
+    }
+  },
+  "mappings": {
+    "properties": {
+      "name": {
+        "type": "text",
+        "analyzer": "tech_index_analyzer",
+        "search_analyzer": "tech_search_analyzer",
+        "fields": {
+          "kw": { "type": "keyword", "normalizer": "tech_normalizer" },
+          "norm": {
+            "type": "text",
+            "analyzer": "tech_keyword_like_analyzer",
+            "search_analyzer": "tech_keyword_like_analyzer"
+          },
+          "suggest": { "type": "completion" }
+        }
+      },
+      "category": { "type": "keyword" },
+      "popularity": { "type": "integer" }
+    }
+  }
+}
+JSON
+
+  curl -s -XPUT "http://localhost:9200/tech_stacks" \
+    -H 'Content-Type: application/json' \
+    --data-binary @/tmp/tech_stacks_mapping.json >/dev/null
+
+  echo "✅ tech_stacks 인덱스 생성 완료"
+}
+
+# -------------------------
+# 컨테이너 기동
+# -------------------------
 echo "🧱 Redis 컨테이너 실행 중..."
-docker-compose up -d redis
-if [ $? -ne 0 ]; then
-  echo "❌ Redis 실행 실패. 도커 설치 상태나 포트를 확인하세요."
-  exit 1
-fi
+docker-compose up -d redis || { echo "❌ Redis 실행 실패"; exit 1; }
 echo "✅ Redis 실행 완료."
 
 echo "🔎 Elasticsearch 컨테이너 실행 중..."
-docker-compose up -d elasticsearch
-if [ $? -ne 0 ]; then
-  echo "❌ Elasticsearch 실행 실패. 도커 설치 상태나 포트를 확인하세요."
-  exit 1
-fi
-echo "✅ Elasticsearch 실행 완료."
+docker-compose up -d elasticsearch || { echo "❌ Elasticsearch 실행 실패"; exit 1; }
+echo "⏳ Elasticsearch health 확인 중..."
+wait_for_es
 
+if [ "$START_KIBANA" = "true" ]; then
+  echo "📊 Kibana 컨테이너 실행 중..."
+  # kibana 서비스가 template에 없으면 실패하므로, 실패해도 계속 진행
+  docker-compose up -d kibana || true
+  # healthcheck 없는 경우 대비하여 수동 상태 대기
+  wait_for_kibana || true
+fi
+
+# -------------------------
+# ES 인덱스 준비
+# -------------------------
+create_or_recreate_techstacks_index
+
+# (옵션) 샘플 한 건 색인해 간단 스모크
+# curl -s -XPOST "http://localhost:9200/tech_stacks/_doc" \
+#   -H 'Content-Type: application/json' \
+#   -d '{ "name": "Spring Boot", "category": "backend", "popularity": 100 }' >/dev/null
+# curl -s -XPOST "http://localhost:9200/tech_stacks/_refresh" >/dev/null
+
+# -------------------------
+# 애플리케이션 기동
+# -------------------------
 echo "🚀 Spring Boot 서버 실행 중..."
 ./gradlew bootRun


### PR DESCRIPTION
## 🔀 PR 제목

[Feature] 기술 스택 검색 API 구현

---

## 📌 작업 내용 요약

- /api/auth/stacks 기술 스택 검색 API 구현

- TechStackSearchService 쿼리 최적화
  - 1~2자 검색어에는 fuzziness=1, 그 외에는 AUTO 적용(오탈자 자동 보정)
  - name.norm(공백 제거 단일 토큰)에 term/prefix 부스트로 정확·접두 매칭 강화
  - name 필드 match에 한–영 동의어(synonym_graph) 적용
  - ES 오류/매핑 문제 시 JPA 페일오버로 빈 리스트 대신 최소 동작 보장

- 한글 검색 완전 지원
  - 예) 자바 → Java, 스프링 → Spring Boot / Spring Security / Spring Data JPA
  - 짧은 한글 오탈자도 보정: 지바 → Java 등

- ES 인덱스 구성 개선 (start-dev.sh 자동화)
  - 인덱스 시점 동의어 확장(synonym) + edge_ngram 필터로 as-you-type 강화
  - 검색 시점 동의어 확장(synonym_graph)으로 쿼리 확장
  - 대상 스택 21종에 맞춘 정제된 동의어 목록만 포함
  
- Dev 편의 스크립트 보강
  - ES/Kibana 헬스체크 & 대기, 인덱스 재생성 토글(FORCE_RECREATE_TECHSTACKS)
  
<img width="457" height="343" alt="스크린샷 2025-08-25 오전 9 50 57" src="https://github.com/user-attachments/assets/89d5e092-c2d0-476f-abf4-ecca8cccc700" />
<img width="452" height="347" alt="스크린샷 2025-08-25 오전 9 50 26" src="https://github.com/user-attachments/assets/ec0bd196-d859-43fa-aa96-fd0c509097de" />
<img width="458" height="374" alt="스크린샷 2025-08-25 오전 9 50 16" src="https://github.com/user-attachments/assets/3ddc8de9-57dd-43ee-ad1f-9a47b68454bb" />

---

## ✅ 체크리스트
PR을 올리기 전에 아래 항목을 확인했나요?

- [ ] 기능 요구사항을 모두 구현했나요?
- [ ] 로컬에서 기능을 직접 테스트했나요?
- [ ] 코드 컨벤션 및 스타일을 지켰나요?
- [ ] 관련된 이슈에 연결했나요?

---

## 🔗 관련 이슈

- Closes #11
- Related to #8

---

## 📎 기타 참고 사항

- 반드시 풀을 받고서는 ./start-dev.sh로 실행해야 합니다.
