### PR TITLE
(feat) 프로젝트 수정 페이지 조회 및 프로젝트 수정 저장 기능

### DIFF
--- a/src/main/java/goorm/ddok/global/dto/LocationDto.java
+++ b/src/main/java/goorm/ddok/global/dto/LocationDto.java
@@ -8,15 +8,31 @@ import java.math.BigDecimal;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
-@Builder
-@Schema(name = "LocationDto", description = "오프라인 위치 정보")
+@Builder(toBuilder = true)
+@Schema(name = "LocationDto", description = "카카오 road_address 매핑 DTO")
 public class LocationDto {
-    @Schema(description = "위도", example = "37.5665")
-    private BigDecimal latitude;
 
-    @Schema(description = "경도", example = "126.9780")
-    private BigDecimal longitude;
-
-    @Schema(description = "주소", example = "서울특별시 강남구 테헤란로…")
+    @Schema(description = "전체 도로명 주소 (address_name)", example = "전북 익산시 망산길 11-17")
     private String address;
+
+    @Schema(description = "광역시/도 (region_1depth_name)", example = "전북")
+    private String region1depthName;
+
+    @Schema(description = "시/군/구 (region_2depth_name)", example = "익산시")
+    private String region2depthName;
+
+    @Schema(description = "동/읍/면 (region_3depth_name)", example = "부송동")
+    private String region3depthName;
+
+    @Schema(description = "도로명 (road_name)", example = "망산길")
+    private String roadName;
+
+    @Schema(description = "우편번호(필요 시) (zone_no)", example = "54547")
+    private String zoneNo;
+
+    @Schema(description = "위도(y)", example = "35.976749396987046")
+    private BigDecimal latitude;   // kakao y
+
+    @Schema(description = "경도(x)", example = "126.99599512792346")
+    private BigDecimal longitude;  // kakao x
 }

--- a/src/main/java/goorm/ddok/global/dto/LocationDto.java
+++ b/src/main/java/goorm/ddok/global/dto/LocationDto.java
@@ -12,27 +12,43 @@ import java.math.BigDecimal;
 @Schema(name = "LocationDto", description = "카카오 road_address 매핑 DTO")
 public class LocationDto {
 
-    @Schema(description = "전체 도로명 주소 (address_name)", example = "전북 익산시 망산길 11-17")
+    @Schema(description = "전체 도로명 주소 (address_name)",
+            example = "전북 익산시 망산길 11-17")
     private String address;
 
-    @Schema(description = "광역시/도 (region_1depth_name)", example = "전북")
+    @Schema(description = "광역시/도 (region_1depth_name)",
+            example = "전북")
     private String region1depthName;
 
-    @Schema(description = "시/군/구 (region_2depth_name)", example = "익산시")
+    @Schema(description = "시/군/구 (region_2depth_name)",
+            example = "익산시")
     private String region2depthName;
 
-    @Schema(description = "동/읍/면 (region_3depth_name)", example = "부송동")
+    @Schema(description = "동/읍/면 (region_3depth_name)",
+            example = "부송동")
     private String region3depthName;
 
-    @Schema(description = "도로명 (road_name)", example = "망산길")
+    @Schema(description = "도로명 (road_name)",
+            example = "망산길")
     private String roadName;
 
-    @Schema(description = "우편번호(필요 시) (zone_no)", example = "54547")
+    @Schema(description = "우편번호(필요 시) (zone_no)",
+            example = "54547")
     private String zoneNo;
 
-    @Schema(description = "위도(y)", example = "35.976749396987046")
+    @Schema(description = "위도(y)",
+            example = "35.976749396987046")
     private BigDecimal latitude;   // kakao y
 
-    @Schema(description = "경도(x)", example = "126.99599512792346")
+    @Schema(description = "경도(x)",
+            example = "126.99599512792346")
     private BigDecimal longitude;  // kakao x
+
+    @Schema(description = "건물 본번 (main_building_no)",
+            example = "11")
+    private String mainBuildingNo;
+
+    @Schema(description = "건물 부번 (sub_building_no)",
+            example = "17")
+    private String subBuildingNo;
 }

--- a/src/main/java/goorm/ddok/global/exception/ErrorCode.java
+++ b/src/main/java/goorm/ddok/global/exception/ErrorCode.java
@@ -22,6 +22,7 @@ public enum ErrorCode {
     INVALID_LOCATION(HttpStatus.BAD_REQUEST, "위치 정보가 올바르지 않습니다."),
     INVALID_START_DATE(HttpStatus.BAD_REQUEST, "시작일은 오늘 이후여야 합니다."),
     INVALID_BOUNDING_BOX(HttpStatus.BAD_REQUEST, "잘못된 지도 경계값입니다."),
+    INVALID_POSITIONS(HttpStatus.BAD_REQUEST,"모집 포지션은 최소 1개 이상이어야 합니다."),
 
     // 401 UNAUTHORIZED
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증이 필요합니다."),

--- a/src/main/java/goorm/ddok/global/exception/ErrorCode.java
+++ b/src/main/java/goorm/ddok/global/exception/ErrorCode.java
@@ -23,6 +23,9 @@ public enum ErrorCode {
     INVALID_START_DATE(HttpStatus.BAD_REQUEST, "시작일은 오늘 이후여야 합니다."),
     INVALID_BOUNDING_BOX(HttpStatus.BAD_REQUEST, "잘못된 지도 경계값입니다."),
     INVALID_POSITIONS(HttpStatus.BAD_REQUEST,"모집 포지션은 최소 1개 이상이어야 합니다."),
+    INVALID_AGE_BUCKET(HttpStatus.BAD_REQUEST, "연령은 10단위(예: 20, 30, 40)만 허용합니다."),
+    INVALID_CAPACITY_POSITIONS(HttpStatus.BAD_REQUEST,"포지션의 개수는 모집인원을 넘을 수 없습니다."),
+    POSITION_IN_USE(HttpStatus.BAD_REQUEST, "참여자/지원 이력 때문에 삭제할 수 없는 포지션입니다."),
 
     // 401 UNAUTHORIZED
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증이 필요합니다."),

--- a/src/main/java/goorm/ddok/project/controller/ProjectRecruitmentEditController.java
+++ b/src/main/java/goorm/ddok/project/controller/ProjectRecruitmentEditController.java
@@ -1,0 +1,182 @@
+package goorm.ddok.project.controller;
+
+import goorm.ddok.global.response.ApiResponseDto;
+import goorm.ddok.global.security.auth.CustomUserDetails;
+import goorm.ddok.project.dto.request.ProjectRecruitmentUpdateRequest;
+import goorm.ddok.project.dto.response.ProjectEditPageResponse;
+import goorm.ddok.project.dto.response.ProjectUpdateResultResponse;
+import goorm.ddok.project.service.ProjectRecruitmentEditService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.*;
+import io.swagger.v3.oas.annotations.responses.*;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.*;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequestMapping("/api/projects")
+@RequiredArgsConstructor
+@Tag(name = "ProjectRecruitment-Edit", description = "프로젝트 수정/조회 API")
+public class ProjectRecruitmentEditController {
+
+    private final ProjectRecruitmentEditService service;
+
+    @Operation(
+            summary = "프로젝트 수정 페이지 조회",
+            description = "수정 화면 진입 시 필요한 상세/통계를 반환합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "수정하기 페이지 조회가 성공했습니다.",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = ApiResponseDto.class),
+                            examples = @ExampleObject(value = """
+                        {
+                          "status": 200,
+                          "message": "수정하기 페이지 조회가 성공했습니다.",
+                          "data": {
+                            "title": "구라라지 프로젝트",
+                            "teamStatus": "RECRUITING",
+                            "bannerImageUrl": "https://cdn.example.com/images/default.png",
+                            "traits": ["정리의 신","실행력 갓","내향인"],
+                            "capacity": 4,
+                            "applicantCount": 6,
+                            "mode": "online",
+                            "address": "online",
+                            "preferredAges": { "ageMin": 20, "ageMax": 30 },
+                            "expectedMonth": 3,
+                            "startDate": "2025-09-10",
+                            "detail": "저희 정말 멋진 웹을 만들거에요~ 하고 싶죠?",
+                            "leaderPosition": "백엔드",
+                            "positions": [
+                              { "positionName": "PM", "applied": 3, "confirmed": 2 },
+                              { "positionName": "UI/UX", "applied": 3, "confirmed": 2 },
+                              { "positionName": "백엔드", "applied": 3, "confirmed": 2 }
+                            ]
+                          }
+                        }"""))),
+            @ApiResponse(responseCode = "401", description = "인증 필요",
+                    content = @Content(schema = @Schema(implementation = ApiResponseDto.class),
+                            examples = @ExampleObject(value = """
+                        { "status": 401, "message": "인증이 필요합니다.", "data": null }"""))),
+            @ApiResponse(responseCode = "403", description = "수정 권한 없음",
+                    content = @Content(schema = @Schema(implementation = ApiResponseDto.class),
+                            examples = @ExampleObject(value = """
+                        { "status": 403, "message": "접근 권한이 없습니다.", "data": null }"""))),
+            @ApiResponse(responseCode = "404", description = "프로젝트 없음",
+                    content = @Content(schema = @Schema(implementation = ApiResponseDto.class),
+                            examples = @ExampleObject(value = """
+                        { "status": 404, "message": "프로젝트를 찾을 수 없습니다.", "data": null }""")))
+    })
+    @GetMapping("/{projectId}/edit")
+    public ResponseEntity<ApiResponseDto<ProjectEditPageResponse>> getEditPage(
+            @PathVariable Long projectId,
+            @AuthenticationPrincipal CustomUserDetails user
+    ) {
+        ProjectEditPageResponse data = service.getEditPage(projectId, user);
+        return ResponseEntity.ok(ApiResponseDto.of(200, "수정하기 페이지 조회가 성공했습니다.", data));
+    }
+
+
+    @Operation(
+            summary = "프로젝트 수정 저장",
+            description = """
+            multipart/form-data 요청. 
+            - `request`: JSON (ProjectRecruitmentUpdateRequest)
+            - `bannerImage`: 파일(선택, image/jpeg|png|webp, 최대 5MB)
+            파일이 있으면 서버가 업로드 후 응답의 bannerImageUrl에 반영합니다.
+            """
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "수정 성공",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = ApiResponseDto.class),
+                            examples = @ExampleObject(value = """
+                        {
+                          "status": 200,
+                          "message": "프로젝트 수정이 성공했습니다.",
+                          "data": {
+                            "projectId": 2,
+                            "isMine": true,
+                            "title": "구라라지 프로젝트",
+                            "teamStatus": "RECRUITING",
+                            "bannerImageUrl": "https://cdn.example.com/images/default.png",
+                            "traits": ["정리의 신","실행력 갓","내향인"],
+                            "capacity": 4,
+                            "applicantCount": 6,
+                            "mode": "online",
+                            "address": "online",
+                            "preferredAges": { "ageMin": 20, "ageMax": 30 },
+                            "expectedMonth": 3,
+                            "startDate": "2025-09-10",
+                            "detail": "저희 정말 멋진 웹을 만들거에요~ 하고 싶죠?",
+                            "positions": [
+                              { "position": "PM", "applied": 3, "confirmed": 2, "isApplied": false, "isApproved": false, "isAvailable": false },
+                              { "position": "UI/UX", "applied": 3, "confirmed": 2, "isApplied": false, "isApproved": false, "isAvailable": false },
+                              { "position": "백엔드", "applied": 3, "confirmed": 2, "isApplied": false, "isApproved": false, "isAvailable": false }
+                            ],
+                            "leader": {
+                              "userId": 101,
+                              "nickname": "개구라",
+                              "profileImageUrl": "https://cdn.example.com/images/user101.png",
+                              "mainPosition": "풀스택",
+                              "temperature": 36.5,
+                              "decidedPosition": "백엔드",
+                              "isMine": true,
+                              "chatRoomId": null,
+                              "dmRequestPending": false
+                            },
+                            "participants": [
+                              {
+                                "userId": 201, "nickname": "개고루",
+                                "profileImageUrl": "https://cdn.example.com/images/user201.png",
+                                "mainPosition": "백엔드", "temperature": 36.5,
+                                "decidedPosition": "백엔드", "isMine": false,
+                                "chatRoomId": null, "dmRequestPending": true
+                              }
+                            ]
+                          }
+                        }"""))),
+            @ApiResponse(responseCode = "400", description = "검증 실패/규칙 위반",
+                    content = @Content(schema = @Schema(implementation = ApiResponseDto.class),
+                            examples = {
+                                    @ExampleObject(name = "과거 시작일", value = """
+                                { "status": 400, "message": "시작일은 오늘 이후여야 합니다.", "data": null }"""),
+                                    @ExampleObject(name = "위치 누락", value = """
+                                { "status": 400, "message": "위치 정보가 올바르지 않습니다.", "data": null }"""),
+                                    @ExampleObject(name = "연령 범위", value = """
+                                { "status": 400, "message": "연령대 범위가 올바르지 않습니다.", "data": null }"""),
+                                    @ExampleObject(name = "포지션 오류", value = """
+                                { "status": 400, "message": "모집 포지션이 올바르지 않습니다.", "data": null }""")
+                            })),
+            @ApiResponse(responseCode = "401", description = "인증 필요",
+                    content = @Content(schema = @Schema(implementation = ApiResponseDto.class),
+                            examples = @ExampleObject(value = """
+                        { "status": 401, "message": "인증이 필요합니다.", "data": null }"""))),
+            @ApiResponse(responseCode = "403", description = "수정 권한 없음",
+                    content = @Content(schema = @Schema(implementation = ApiResponseDto.class),
+                            examples = @ExampleObject(value = """
+                        { "status": 403, "message": "접근 권한이 없습니다.", "data": null }"""))),
+            @ApiResponse(responseCode = "404", description = "프로젝트 없음",
+                    content = @Content(schema = @Schema(implementation = ApiResponseDto.class),
+                            examples = @ExampleObject(value = """
+                        { "status": 404, "message": "프로젝트를 찾을 수 없습니다.", "data": null }"""))),
+            @ApiResponse(responseCode = "500", description = "배너 업로드 실패 등 서버 오류",
+                    content = @Content(schema = @Schema(implementation = ApiResponseDto.class),
+                            examples = @ExampleObject(value = """
+                        { "status": 500, "message": "배너 이미지 업로드에 실패했습니다.", "data": null }""")))
+    })
+    @PatchMapping(value = "/{projectId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<ApiResponseDto<ProjectUpdateResultResponse>> update(
+            @PathVariable Long projectId,
+            @RequestPart("request") @Valid ProjectRecruitmentUpdateRequest request,
+            @RequestPart(value = "bannerImage", required = false) MultipartFile bannerImage,
+            @AuthenticationPrincipal CustomUserDetails user
+    ) {
+        ProjectUpdateResultResponse data = service.updateProject(projectId, request, bannerImage, user);
+        return ResponseEntity.ok(ApiResponseDto.of(200, "프로젝트 수정이 성공했습니다.", data));
+    }
+}

--- a/src/main/java/goorm/ddok/project/domain/ProjectParticipant.java
+++ b/src/main/java/goorm/ddok/project/domain/ProjectParticipant.java
@@ -54,4 +54,8 @@ public class ProjectParticipant {
     /** 삭제 시각(Soft Delete */
     @Column
     private Instant deletedAt;
+
+    public void changePosition(ProjectRecruitmentPosition newPos) {
+        this.position = newPos;
+    }
 }

--- a/src/main/java/goorm/ddok/project/dto/request/ProjectRecruitmentUpdateRequest.java
+++ b/src/main/java/goorm/ddok/project/dto/request/ProjectRecruitmentUpdateRequest.java
@@ -1,0 +1,61 @@
+package goorm.ddok.project.dto.request;
+
+import goorm.ddok.global.dto.LocationDto;
+import goorm.ddok.global.dto.PreferredAgesDto;
+import goorm.ddok.project.domain.ProjectMode;
+import goorm.ddok.project.domain.TeamStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.*;
+import lombok.*;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder(toBuilder = true)
+@Schema(name = "ProjectRecruitmentUpdateRequest", description = "프로젝트 수정 요청 DTO")
+public class ProjectRecruitmentUpdateRequest {
+
+    @NotBlank @Size(min = 2, max = 30)
+    private String title;
+
+    @NotNull
+    private LocalDate expectedStart;
+
+    @NotNull @Min(1) @Max(64)
+    private Integer expectedMonth;
+
+    @NotNull
+    private ProjectMode mode;
+
+    /** OFFLINE일 때만 사용 */
+    private LocationDto location;
+
+    /** 없으면 null */
+    private PreferredAgesDto preferredAges;
+
+    @NotNull @Min(1) @Max(7)
+    private Integer capacity;
+
+    /** 성향 목록 (없으면 빈 목록/유지) */
+    private List<String> traits;
+
+    /** 모집 포지션(최소 1개) */
+    @NotEmpty(message = "모집 포지션은 최소 1개 이상이어야 합니다.")
+    private List<String> positions;
+
+    /** 리더 포지션명(선택) – 정책에 따라 사용/검증 */
+    @NotBlank(message = "리더 포지션은 필수 입력값입니다.")
+    private String leaderPosition;
+
+    @NotBlank @Size(min = 10, max = 2000)
+    private String detail;
+
+    /** 배너 이미지 URL (파일 미첨부 시 변경/유지 용) */
+    private String bannerImageUrl;
+
+    @NotNull
+    private TeamStatus teamStatus;
+}

--- a/src/main/java/goorm/ddok/project/dto/request/ProjectRecruitmentUpdateRequest.java
+++ b/src/main/java/goorm/ddok/project/dto/request/ProjectRecruitmentUpdateRequest.java
@@ -18,44 +18,56 @@ import java.util.List;
 @Schema(name = "ProjectRecruitmentUpdateRequest", description = "프로젝트 수정 요청 DTO")
 public class ProjectRecruitmentUpdateRequest {
 
-    @NotBlank @Size(min = 2, max = 30)
+    @NotBlank
+    @Size(min = 2, max = 30)
+    @Schema(example = "구지라지")
     private String title;
 
     @NotNull
+    @Schema(example = "2025-09-15", description = "프로젝트 시작 예정일(오늘 또는 미래)")
     private LocalDate expectedStart;
 
-    @NotNull @Min(1) @Max(64)
+    @NotNull
+    @Min(1) @Max(64)
+    @Schema(example = "3")
     private Integer expectedMonth;
 
     @NotNull
+    @Schema(example = "OFFLINE", allowableValues = {"ONLINE","OFFLINE"})
     private ProjectMode mode;
 
-    /** OFFLINE일 때만 사용 */
+    @Schema(description = "OFFLINE 필수. 카카오 road_address 매핑값 사용")
     private LocationDto location;
 
-    /** 없으면 null */
+    @Schema(description = "없으면 null")
     private PreferredAgesDto preferredAges;
 
-    @NotNull @Min(1) @Max(7)
+    @NotNull
+    @Min(1) @Max(7)
+    @Schema(example = "6")
     private Integer capacity;
 
-    /** 성향 목록 (없으면 빈 목록/유지) */
+    @Schema(example = "[\"정리의 신\",\"실행력 갓\",\"내향인\"]")
     private List<String> traits;
 
-    /** 모집 포지션(최소 1개) */
-    @NotEmpty(message = "모집 포지션은 최소 1개 이상이어야 합니다.")
+    @NotEmpty(message = "모집 포지션은 1개 이상이어야 합니다.")
+    @Schema(example = "[\"PM\",\"UI/UX\",\"백엔드\"]")
     private List<String> positions;
 
-    /** 리더 포지션명(선택) – 정책에 따라 사용/검증 */
-    @NotBlank(message = "리더 포지션은 필수 입력값입니다.")
+    @NotBlank(message = "리더 포지션은 필수입니다.")
+    @Schema(example = "PM")
     private String leaderPosition;
 
-    @NotBlank @Size(min = 10, max = 2000)
+    @NotBlank
+    @Size(min = 10, max = 2000)
+    @Schema(example = "멋진 웹을 함께 만들 사람을 찾습니다.")
     private String detail;
 
-    /** 배너 이미지 URL (파일 미첨부 시 변경/유지 용) */
+    @Schema(description = "파일 미첨부 시 변경/유지 위해 사용 가능",
+            example = "https://cdn.example.com/images/default.png")
     private String bannerImageUrl;
 
     @NotNull
+    @Schema(example = "RECRUITING", allowableValues = {"RECRUITING","ONGOING","CLOSED"})
     private TeamStatus teamStatus;
 }

--- a/src/main/java/goorm/ddok/project/dto/response/ProjectEditPageResponse.java
+++ b/src/main/java/goorm/ddok/project/dto/response/ProjectEditPageResponse.java
@@ -1,0 +1,34 @@
+package goorm.ddok.project.dto.response;
+
+import goorm.ddok.global.dto.PreferredAgesDto;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Builder
+@Schema(name = "ProjectEditPageResponse")
+public record ProjectEditPageResponse(
+        String title,
+        String teamStatus,
+        String bannerImageUrl,
+        List<String> traits,
+        Integer capacity,
+        Long applicantCount,
+        String mode,
+        String address,
+        PreferredAgesDto preferredAges,
+        Integer expectedMonth,
+        LocalDate startDate,
+        String detail,
+        String leaderPosition,
+        List<PositionItem> positions
+) {
+    @Builder
+    public record PositionItem(
+            String positionName,
+            Long applied,
+            Long confirmed
+    ) {}
+}

--- a/src/main/java/goorm/ddok/project/dto/response/ProjectUpdateResultResponse.java
+++ b/src/main/java/goorm/ddok/project/dto/response/ProjectUpdateResultResponse.java
@@ -12,7 +12,7 @@ import java.util.List;
 public class ProjectUpdateResultResponse {
 
     private Long projectId;
-    private boolean isMine;
+    private boolean IsMine;
 
     private String title;
     private String teamStatus;

--- a/src/main/java/goorm/ddok/project/dto/response/ProjectUpdateResultResponse.java
+++ b/src/main/java/goorm/ddok/project/dto/response/ProjectUpdateResultResponse.java
@@ -1,0 +1,77 @@
+package goorm.ddok.project.dto.response;
+
+import goorm.ddok.global.dto.PreferredAgesDto;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+@Builder
+public class ProjectUpdateResultResponse {
+
+    private Long projectId;
+    private boolean isMine;
+
+    private String title;
+    private String teamStatus;
+    private String bannerImageUrl;
+
+    private List<String> traits;
+    private Integer capacity;
+    private Long applicantCount;
+
+    private String mode;     // "online" | "offline"
+    private String address;  // offline: 도로명 / online: "online"
+
+    private PreferredAgesDto preferredAges;
+
+    private Integer expectedMonth;
+    private LocalDate startDate;
+
+    private String detail;
+
+    private List<PositionItem> positions;
+    private LeaderBlock leader;                 // 리더 정보
+    private List<ParticipantBlock> participants;// 멤버 목록
+
+    @Getter
+    @Builder
+    public static class PositionItem {
+        private String position;
+        private Long applied;
+        private Long confirmed;
+        private boolean isApplied;   // 내 지원 여부
+        private boolean isApproved;  // 내 승인 여부
+        private boolean isAvailable; // 단순 모집중 여부
+    }
+
+    @Getter
+    @Builder
+    public static class LeaderBlock {
+        private Long userId;
+        private String nickname;
+        private String profileImageUrl;
+        private String mainPosition;
+        private Double temperature;
+        private String decidedPosition;
+        private boolean isMine;
+        private Long chatRoomId;
+        private boolean dmRequestPending;
+    }
+
+    @Getter
+    @Builder
+    public static class ParticipantBlock {
+        private Long userId;
+        private String nickname;
+        private String profileImageUrl;
+        private String mainPosition;
+        private Double temperature;
+        private String decidedPosition;
+        private boolean isMine;
+        private Long chatRoomId;
+        private boolean dmRequestPending;
+    }
+}

--- a/src/main/java/goorm/ddok/project/dto/response/ProjectUpdateResultResponse.java
+++ b/src/main/java/goorm/ddok/project/dto/response/ProjectUpdateResultResponse.java
@@ -42,9 +42,9 @@ public class ProjectUpdateResultResponse {
         private String position;
         private Long applied;
         private Long confirmed;
-        private boolean isApplied;   // 내 지원 여부
-        private boolean isApproved;  // 내 승인 여부
-        private boolean isAvailable; // 단순 모집중 여부
+        private boolean IsApplied;   // 내 지원 여부
+        private boolean IsApproved;  // 내 승인 여부
+        private boolean IsAvailable; // 단순 모집중 여부
     }
 
     @Getter
@@ -56,7 +56,7 @@ public class ProjectUpdateResultResponse {
         private String mainPosition;
         private Double temperature;
         private String decidedPosition;
-        private boolean isMine;
+        private boolean IsMine;
         private Long chatRoomId;
         private boolean dmRequestPending;
     }
@@ -70,7 +70,7 @@ public class ProjectUpdateResultResponse {
         private String mainPosition;
         private Double temperature;
         private String decidedPosition;
-        private boolean isMine;
+        private boolean IsMine;
         private Long chatRoomId;
         private boolean dmRequestPending;
     }

--- a/src/main/java/goorm/ddok/project/repository/ProjectApplicationRepository.java
+++ b/src/main/java/goorm/ddok/project/repository/ProjectApplicationRepository.java
@@ -1,12 +1,64 @@
 package goorm.ddok.project.repository;
 
+import goorm.ddok.project.domain.ApplicationStatus;
 import goorm.ddok.project.domain.ProjectApplication;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface ProjectApplicationRepository extends JpaRepository<ProjectApplication, Long> {
 
     Optional<ProjectApplication> findByUser_IdAndPosition_ProjectRecruitment_Id(Long userId, Long positionId);
+
+    // 프로젝트 기준 전체 지원 수
+    @Query("""
+           select count(a)
+           from ProjectApplication a
+           where a.position.projectRecruitment.id = :projectId
+           """)
+    long countAllByProjectId(Long projectId);
+
+    // 포지션별 applied 집계
+    interface PositionCountProjection {
+        String getPositionName();
+        Long getCnt();
+    }
+
+    @Query("""
+           select a.position.positionName as positionName, count(a) as cnt
+           from ProjectApplication a
+           where a.position.projectRecruitment.id = :projectId
+           group by a.position.positionName
+           """)
+    List<PositionCountProjection> countAppliedByPosition(Long projectId);
+
+    // 포지션별 approved 집계
+    @Query("""
+           select a.position.positionName as positionName, count(a) as cnt
+           from ProjectApplication a
+           where a.position.projectRecruitment.id = :projectId
+             and a.status = goorm.ddok.project.domain.ApplicationStatus.APPROVED
+           group by a.position.positionName
+           """)
+    List<PositionCountProjection> countApprovedByPosition(Long projectId);
+
+    // 내 지원 여부
+    boolean existsByUser_IdAndPosition_ProjectRecruitment_Id(Long userId, Long projectId);
+
+    // 내 승인 여부
+    boolean existsByUser_IdAndPosition_ProjectRecruitment_IdAndStatus(Long userId, Long projectId, ApplicationStatus status);
+
+    // 특정 포지션 참조 지원 수
+    long countByPosition_Id(Long positionId);
+
+    // 프로젝트 참가자(멤버) 제외하고 ‘지원자 현황’ 만들 때 사용할 원본(필요시)
+    @Query("""
+           select a
+           from ProjectApplication a
+           where a.position.projectRecruitment.id = :projectId
+           """)
+    List<ProjectApplication> findAllByProject(Long projectId);
 
 }

--- a/src/main/java/goorm/ddok/project/repository/ProjectParticipantRepository.java
+++ b/src/main/java/goorm/ddok/project/repository/ProjectParticipantRepository.java
@@ -1,7 +1,21 @@
 package goorm.ddok.project.repository;
 
+import goorm.ddok.project.domain.ParticipantRole;
 import goorm.ddok.project.domain.ProjectParticipant;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+import java.util.Optional;
+
 public interface ProjectParticipantRepository extends JpaRepository<ProjectParticipant, Long> {
+    // 프로젝트 기준 참가자(리더/멤버)
+    List<ProjectParticipant> findByPosition_ProjectRecruitment_IdAndDeletedAtIsNull(Long projectId);
+
+    // 프로젝트의 리더 1명
+    Optional<ProjectParticipant> findFirstByPosition_ProjectRecruitment_IdAndRoleAndDeletedAtIsNull(
+            Long projectId, ParticipantRole role
+    );
+
+    // 특정 포지션을 참조하는 참가자 수
+    long countByPosition_IdAndDeletedAtIsNull(Long positionId);
 }

--- a/src/main/java/goorm/ddok/project/service/ProjectRecruitmentEditService.java
+++ b/src/main/java/goorm/ddok/project/service/ProjectRecruitmentEditService.java
@@ -322,7 +322,7 @@ public class ProjectRecruitmentEditService {
                             .mainPosition(null)      // 필요 시 사용자 포지션 연계
                             .temperature(null)       // 필요 시 연계
                             .decidedPosition(pp.getPosition() != null ? pp.getPosition().getPositionName() : null)
-                            .isMine(mine)
+                            .IsMine(mine)
                             .chatRoomId(null)
                             .dmRequestPending(false)
                             .build();
@@ -344,7 +344,7 @@ public class ProjectRecruitmentEditService {
                             .mainPosition(null)
                             .temperature(null)
                             .decidedPosition(pp.getPosition() != null ? pp.getPosition().getPositionName() : null)
-                            .isMine(meId != null && Objects.equals(meId, u.getId()))
+                            .IsMine(meId != null && Objects.equals(meId, u.getId()))
                             .chatRoomId(null)
                             .dmRequestPending(false)
                             .build();
@@ -379,9 +379,9 @@ public class ProjectRecruitmentEditService {
                         .position(p.getPositionName())
                         .applied(applied.getOrDefault(p.getPositionName(), 0L))
                         .confirmed(confirmed.getOrDefault(p.getPositionName(), 0L))
-                        .isApplied(myApplied)
-                        .isApproved(myApproved)
-                        .isAvailable(pr.getTeamStatus() == TeamStatus.RECRUITING)
+                        .IsApplied(myApplied)
+                        .IsApproved(myApproved)
+                        .IsAvailable(pr.getTeamStatus() == TeamStatus.RECRUITING)
                         .build())
                 .toList();
 

--- a/src/main/java/goorm/ddok/project/service/ProjectRecruitmentEditService.java
+++ b/src/main/java/goorm/ddok/project/service/ProjectRecruitmentEditService.java
@@ -1,0 +1,414 @@
+package goorm.ddok.project.service;
+
+import goorm.ddok.global.dto.LocationDto;
+import goorm.ddok.global.dto.PreferredAgesDto;
+import goorm.ddok.global.exception.ErrorCode;
+import goorm.ddok.global.exception.GlobalException;
+import goorm.ddok.global.file.FileService;
+import goorm.ddok.global.security.auth.CustomUserDetails;
+import goorm.ddok.global.util.BannerImageService;
+import goorm.ddok.member.domain.User;
+import goorm.ddok.project.domain.*;
+import goorm.ddok.project.dto.request.ProjectRecruitmentUpdateRequest;
+import goorm.ddok.project.dto.response.ProjectEditPageResponse;
+import goorm.ddok.project.dto.response.ProjectUpdateResultResponse;
+import goorm.ddok.project.repository.ProjectApplicationRepository;
+import goorm.ddok.project.repository.ProjectParticipantRepository;
+import goorm.ddok.project.repository.ProjectRecruitmentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ProjectRecruitmentEditService {
+
+    private final ProjectRecruitmentRepository recruitmentRepository;
+    private final ProjectParticipantRepository participantRepository;
+    private final ProjectApplicationRepository applicationRepository;
+    private final FileService fileService;
+    private final BannerImageService bannerImageService;
+
+    /* =========================
+     *  수정 페이지 조회
+     * ========================= */
+    @Transactional(readOnly = true)
+    public ProjectEditPageResponse getEditPage(Long projectId, CustomUserDetails me) {
+        if (me == null || me.getUser() == null) throw new GlobalException(ErrorCode.UNAUTHORIZED);
+
+        ProjectRecruitment pr = recruitmentRepository.findById(projectId)
+                .orElseThrow(() -> new GlobalException(ErrorCode.PROJECT_NOT_FOUND));
+
+        // 소유자만 조회 허용(정책에 맞게 수정 가능)
+        if (!Objects.equals(pr.getUser().getId(), me.getUser().getId())) {
+            throw new GlobalException(ErrorCode.FORBIDDEN);
+        }
+
+        long applicantCount = applicationRepository.countAllByProjectId(projectId);
+
+        Map<String, Long> applied = applicationRepository.countAppliedByPosition(projectId)
+                .stream().collect(Collectors.toMap(
+                        ProjectApplicationRepository.PositionCountProjection::getPositionName,
+                        ProjectApplicationRepository.PositionCountProjection::getCnt
+                ));
+
+        Map<String, Long> confirmed = applicationRepository.countApprovedByPosition(projectId)
+                .stream().collect(Collectors.toMap(
+                        ProjectApplicationRepository.PositionCountProjection::getPositionName,
+                        ProjectApplicationRepository.PositionCountProjection::getCnt
+                ));
+
+        List<ProjectEditPageResponse.PositionItem> positions = pr.getPositions().stream()
+                .map(p -> new ProjectEditPageResponse.PositionItem(
+                        p.getPositionName(),
+                        applied.getOrDefault(p.getPositionName(), 0L),
+                        confirmed.getOrDefault(p.getPositionName(), 0L)
+                ))
+                .toList();
+
+        String address = pr.getProjectMode() == ProjectMode.ONLINE
+                ? "ONLINE"
+                : Optional.ofNullable(pr.getRoadName()).orElse("-");
+
+        return ProjectEditPageResponse.builder()
+                .title(pr.getTitle())
+                .teamStatus(pr.getTeamStatus().name())
+                .bannerImageUrl(pr.getBannerImageUrl())
+                .traits(pr.getTraits().stream().map(ProjectRecruitmentTrait::getTraitName).toList())
+                .capacity(pr.getCapacity())
+                .applicantCount(applicantCount)
+                .mode(pr.getProjectMode().name().toLowerCase())
+                .address(address)
+                .preferredAges(new PreferredAgesDto(pr.getAgeMin(), pr.getAgeMax()))
+                .expectedMonth(pr.getExpectedMonths())
+                .startDate(pr.getStartDate())
+                .detail(pr.getContentMd())
+                .leaderPosition(resolveLeaderPositionName(projectId))
+                .positions(positions)
+                .build();
+    }
+
+    /* =========================
+     *  수정 저장 (업데이트 방식)
+     * ========================= */
+    public ProjectUpdateResultResponse updateProject(Long projectId,
+                                                     ProjectRecruitmentUpdateRequest req,
+                                                     MultipartFile bannerImage,
+                                                     CustomUserDetails me) {
+        if (me == null || me.getUser() == null) throw new GlobalException(ErrorCode.UNAUTHORIZED);
+
+        ProjectRecruitment pr = recruitmentRepository.findById(projectId)
+                .orElseThrow(() -> new GlobalException(ErrorCode.PROJECT_NOT_FOUND));
+
+        // 리더 권한
+        if (!Objects.equals(pr.getUser().getId(), me.getUser().getId())) {
+            throw new GlobalException(ErrorCode.FORBIDDEN);
+        }
+
+        // 시작일 미래 검증 (오늘 이후만 허용)
+        if (req.getExpectedStart() != null) {
+            java.time.LocalDate today = java.time.LocalDate.now();
+            if (!req.getExpectedStart().isAfter(today)) {
+                throw new GlobalException(ErrorCode.INVALID_START_DATE);
+            }
+        }
+
+        // 연령/모드/위치 등 기존 검증 ...
+        if (req.getPreferredAges() != null &&
+                req.getPreferredAges().getAgeMin() > req.getPreferredAges().getAgeMax()) {
+            throw new GlobalException(ErrorCode.INVALID_AGE_RANGE);
+        }
+        if (req.getPositions() == null || req.getPositions().isEmpty()) {
+            throw new GlobalException(ErrorCode.INVALID_POSITIONS);
+        }
+        if (req.getMode() == ProjectMode.OFFLINE) {
+            LocationDto loc = req.getLocation();
+            if (loc == null || loc.getLatitude() == null || loc.getLongitude() == null) {
+                throw new GlobalException(ErrorCode.INVALID_LOCATION);
+            }
+        }
+
+        // ✅ [추가] 리더 포지션 검증: 요청 포지션 목록에 반드시 포함되어야 함
+        String leaderPosName = (req.getLeaderPosition() == null) ? "" : req.getLeaderPosition().trim();
+        java.util.List<String> desiredPositions =
+                req.getPositions().stream().filter(Objects::nonNull)
+                        .map(String::trim).filter(s -> !s.isBlank())
+                        .distinct().collect(Collectors.toList());
+
+        if (leaderPosName.isBlank() || !desiredPositions.contains(leaderPosName)) {
+            throw new GlobalException(ErrorCode.INVALID_LEADER_POSITION);
+        }
+
+        // 배너 URL 선택
+        String bannerUrl = resolveBannerUrl(bannerImage, req.getBannerImageUrl(), pr.getBannerImageUrl(), req.getTitle());
+
+        // 위치 업데이트
+        boolean offline = req.getMode() == ProjectMode.OFFLINE;
+        pr = offline ? updateOfflineLocation(pr, req.getLocation()) : clearLocation(pr);
+
+        // 기본 필드 업데이트
+        int ageMin = (req.getPreferredAges() != null) ? req.getPreferredAges().getAgeMin() : pr.getAgeMin();
+        int ageMax = (req.getPreferredAges() != null) ? req.getPreferredAges().getAgeMax() : pr.getAgeMax();
+
+        pr = pr.toBuilder()
+                .title(req.getTitle())
+                .teamStatus(req.getTeamStatus())
+                .startDate(req.getExpectedStart())
+                .expectedMonths(req.getExpectedMonth())
+                .projectMode(req.getMode())
+                .bannerImageUrl(bannerUrl)
+                .contentMd(req.getDetail())
+                .capacity(req.getCapacity())
+                .ageMin(ageMin)
+                .ageMax(ageMax)
+                .build();
+
+        // 포지션/성향 머지
+        mergeTraits(pr, req.getTraits());
+        mergePositions(pr, desiredPositions);
+
+        // ✅ [추가] 리더 Participant의 포지션을 요청의 leaderPosition으로 동기화
+        // (mergePositions 이후 pr.getPositions() 안에 반드시 존재)
+        ProjectRecruitmentPosition leaderPosEntity = pr.getPositions().stream()
+                .filter(p -> p.getPositionName().equals(leaderPosName))
+                .findFirst()
+                .orElseThrow(() -> new GlobalException(ErrorCode.INVALID_LEADER_POSITION));
+
+        participantRepository
+                .findFirstByPosition_ProjectRecruitment_IdAndRoleAndDeletedAtIsNull(projectId, ParticipantRole.LEADER)
+                .ifPresent(pp -> {
+                    // 이미 같지 않으면 변경
+                    if (pp.getPosition() == null || !Objects.equals(pp.getPosition().getId(), leaderPosEntity.getId())) {
+                        pp.changePosition(leaderPosEntity);
+                        participantRepository.save(pp);
+                    }
+                });
+
+        ProjectRecruitment saved = recruitmentRepository.save(pr);
+        return buildUpdateResult(saved, me);
+    }
+
+    /* ---------- merge helpers ---------- */
+
+    private void mergeTraits(ProjectRecruitment pr, List<String> incoming) {
+        List<String> desired = (incoming == null) ? List.of() : incoming.stream()
+                .filter(Objects::nonNull).map(String::trim).filter(s -> !s.isBlank()).distinct().toList();
+
+        // 현재 맵
+        Map<String, ProjectRecruitmentTrait> current = pr.getTraits().stream()
+                .collect(Collectors.toMap(ProjectRecruitmentTrait::getTraitName, t -> t, (a,b)->a));
+
+        // 추가
+        for (String name : desired) {
+            if (!current.containsKey(name)) {
+                pr.getTraits().add(ProjectRecruitmentTrait.builder()
+                        .projectRecruitment(pr)
+                        .traitName(name)
+                        .build());
+            }
+        }
+        // 제거 (원본에만 있고 신규에는 없는 것)
+        pr.getTraits().removeIf(t -> !desired.contains(t.getTraitName()));
+    }
+
+    /**
+     * 포지션은 ‘이름 기준’으로 머지한다.
+     * - 신규는 추가
+     * - 원본에만 있는 이름은 삭제 시도하되, 지원/참가자 참조가 있으면 **유지**
+     */
+    private void mergePositions(ProjectRecruitment pr, List<String> incoming) {
+        List<String> desired = incoming.stream()
+                .filter(Objects::nonNull).map(String::trim).filter(s -> !s.isBlank()).distinct().toList();
+
+        Map<String, ProjectRecruitmentPosition> byName = pr.getPositions().stream()
+                .collect(Collectors.toMap(ProjectRecruitmentPosition::getPositionName, p -> p, (a,b)->a));
+
+        // 추가
+        for (String name : desired) {
+            if (!byName.containsKey(name)) {
+                pr.getPositions().add(ProjectRecruitmentPosition.builder()
+                        .projectRecruitment(pr)
+                        .positionName(name)
+                        .build());
+            }
+        }
+
+        // 삭제(참조 없는 경우에만)
+        Iterator<ProjectRecruitmentPosition> it = pr.getPositions().iterator();
+        while (it.hasNext()) {
+            ProjectRecruitmentPosition pos = it.next();
+            if (!desired.contains(pos.getPositionName())) {
+                long refByParticipants = participantRepository.countByPosition_IdAndDeletedAtIsNull(pos.getId());
+                long refByApplications = applicationRepository.countByPosition_Id(pos.getId());
+                if (refByParticipants == 0 && refByApplications == 0) {
+                    it.remove();
+                }
+                // 참조가 있으면 그대로 둠
+            }
+        }
+    }
+
+    /* ---------- location helpers ---------- */
+
+    private ProjectRecruitment updateOfflineLocation(ProjectRecruitment pr, LocationDto loc) {
+        BigDecimal lat = loc.getLatitude();
+        BigDecimal lng = loc.getLongitude();
+        String addr = loc.getAddress();
+
+        return pr.toBuilder()
+                .region1depthName("서울특별시")   // TODO: 실제 파서로 교체
+                .region2depthName("강남구")
+                .region3depthName("테헤란로")
+                .roadName(addr)
+                .latitude(lat)
+                .longitude(lng)
+                .build();
+    }
+
+    private ProjectRecruitment clearLocation(ProjectRecruitment pr) {
+        return pr.toBuilder()
+                .region1depthName(null)
+                .region2depthName(null)
+                .region3depthName(null)
+                .roadName(null)
+                .latitude(null)
+                .longitude(null)
+                .build();
+    }
+
+    /* ---------- banner helper ---------- */
+    private String resolveBannerUrl(MultipartFile file, String requestUrl, String currentUrl, String titleForDefault) {
+        if (file != null && !file.isEmpty()) {
+            try {
+                return fileService.upload(file);
+            } catch (IOException e) {
+                throw new GlobalException(ErrorCode.BANNER_UPLOAD_FAILED);
+            }
+        }
+        if (requestUrl != null && !requestUrl.isBlank()) return requestUrl.trim();
+        if (currentUrl != null && !currentUrl.isBlank()) return currentUrl;
+        return bannerImageService.generateBannerImageUrl(
+                (titleForDefault == null ? "PROJECT" : titleForDefault), "PROJECT", 1200, 600
+        );
+    }
+
+    /* ---------- response builders ---------- */
+
+    private String resolveLeaderPositionName(Long projectId) {
+        return participantRepository
+                .findFirstByPosition_ProjectRecruitment_IdAndRoleAndDeletedAtIsNull(projectId, ParticipantRole.LEADER)
+                .map(pp -> pp.getPosition() != null ? pp.getPosition().getPositionName() : null)
+                .orElse(null);
+    }
+
+    private ProjectUpdateResultResponse.LeaderBlock resolveLeader(Long projectId, CustomUserDetails me) {
+        return participantRepository
+                .findFirstByPosition_ProjectRecruitment_IdAndRoleAndDeletedAtIsNull(projectId, ParticipantRole.LEADER)
+                .map(pp -> {
+                    User u = pp.getUser();
+                    boolean mine = me != null && me.getUser() != null && Objects.equals(u.getId(), me.getUser().getId());
+                    return ProjectUpdateResultResponse.LeaderBlock.builder()
+                            .userId(u.getId())
+                            .nickname(u.getNickname())
+                            .profileImageUrl(u.getProfileImageUrl())
+                            .mainPosition(null)      // 필요 시 사용자 포지션 연계
+                            .temperature(null)       // 필요 시 연계
+                            .decidedPosition(pp.getPosition() != null ? pp.getPosition().getPositionName() : null)
+                            .isMine(mine)
+                            .chatRoomId(null)
+                            .dmRequestPending(false)
+                            .build();
+                })
+                .orElse(null);
+    }
+
+    private List<ProjectUpdateResultResponse.ParticipantBlock> resolveParticipants(Long projectId, CustomUserDetails me) {
+        Long meId = (me != null && me.getUser() != null) ? me.getUser().getId() : null;
+
+        return participantRepository.findByPosition_ProjectRecruitment_IdAndDeletedAtIsNull(projectId).stream()
+                .filter(pp -> pp.getRole() == ParticipantRole.MEMBER) // 리더 제외
+                .map(pp -> {
+                    User u = pp.getUser();
+                    return ProjectUpdateResultResponse.ParticipantBlock.builder()
+                            .userId(u.getId())
+                            .nickname(u.getNickname())
+                            .profileImageUrl(u.getProfileImageUrl())
+                            .mainPosition(null)
+                            .temperature(null)
+                            .decidedPosition(pp.getPosition() != null ? pp.getPosition().getPositionName() : null)
+                            .isMine(meId != null && Objects.equals(meId, u.getId()))
+                            .chatRoomId(null)
+                            .dmRequestPending(false)
+                            .build();
+                })
+                .toList();
+    }
+
+    private ProjectUpdateResultResponse buildUpdateResult(ProjectRecruitment pr, CustomUserDetails me) {
+        Long projectId = pr.getId();
+
+        long applicantCount = applicationRepository.countAllByProjectId(projectId);
+
+        Map<String, Long> applied = applicationRepository.countAppliedByPosition(projectId).stream()
+                .collect(Collectors.toMap(
+                        ProjectApplicationRepository.PositionCountProjection::getPositionName,
+                        ProjectApplicationRepository.PositionCountProjection::getCnt
+                ));
+        Map<String, Long> confirmed = applicationRepository.countApprovedByPosition(projectId).stream()
+                .collect(Collectors.toMap(
+                        ProjectApplicationRepository.PositionCountProjection::getPositionName,
+                        ProjectApplicationRepository.PositionCountProjection::getCnt
+                ));
+
+        Long meId = (me != null && me.getUser() != null) ? me.getUser().getId() : null;
+        boolean myApplied = (meId != null) && applicationRepository
+                .existsByUser_IdAndPosition_ProjectRecruitment_Id(meId, projectId);
+        boolean myApproved = (meId != null) && applicationRepository
+                .existsByUser_IdAndPosition_ProjectRecruitment_IdAndStatus(meId, projectId, ApplicationStatus.APPROVED);
+
+        List<ProjectUpdateResultResponse.PositionItem> positionItems = pr.getPositions().stream()
+                .map(p -> ProjectUpdateResultResponse.PositionItem.builder()
+                        .position(p.getPositionName())
+                        .applied(applied.getOrDefault(p.getPositionName(), 0L))
+                        .confirmed(confirmed.getOrDefault(p.getPositionName(), 0L))
+                        .isApplied(myApplied)
+                        .isApproved(myApproved)
+                        .isAvailable(pr.getTeamStatus() == TeamStatus.RECRUITING)
+                        .build())
+                .toList();
+
+        String address = pr.getProjectMode() == ProjectMode.ONLINE
+                ? "ONLINE"
+                : Optional.ofNullable(pr.getRoadName()).orElse("-");
+
+        boolean isMine = meId != null && Objects.equals(pr.getUser().getId(), meId);
+
+        return ProjectUpdateResultResponse.builder()
+                .projectId(projectId)
+                .isMine(isMine)
+                .title(pr.getTitle())
+                .teamStatus(pr.getTeamStatus().name())
+                .bannerImageUrl(pr.getBannerImageUrl())
+                .traits(pr.getTraits().stream().map(ProjectRecruitmentTrait::getTraitName).toList())
+                .capacity(pr.getCapacity())
+                .applicantCount(applicantCount)
+                .mode(pr.getProjectMode().name().toLowerCase())
+                .address(address)
+                .preferredAges(new PreferredAgesDto(pr.getAgeMin(), pr.getAgeMax()))
+                .expectedMonth(pr.getExpectedMonths())
+                .startDate(pr.getStartDate())
+                .detail(pr.getContentMd())
+                .positions(positionItems)
+                .leader(resolveLeader(projectId, me))
+                .participants(resolveParticipants(projectId, me))
+                .build();
+    }
+}


### PR DESCRIPTION
## 🔀 PR 제목
- [Feature] 프로젝트 수정 페이지 조회 및 프로젝트 수정 저장 기능

---

## 📌 작업 내용 요약
어떤 작업을 했는지 간략히 설명해주세요.

- 프로젝트 조회 
- 프로젝트 수정 저장
- 프로젝트 수정 저장 시 연령대, 온오프라인, 참여이력 포지션 삭제 금지 등 로직 추가

---

## ✅ 체크리스트
PR을 올리기 전에 아래 항목을 확인했나요?

- [ ] 기능 요구사항을 모두 구현했나요?
- [ ] 로컬에서 기능을 직접 테스트했나요?
- [ ] 코드 컨벤션 및 스타일을 지켰나요?
- [ ] 관련된 이슈에 연결했나요?

---

## 🔗 관련 이슈
`Closes #이슈번호` 또는 `Related to #이슈번호` 형태로 작성

예시:
- Closes #37
- Related to #37
---

## 📎 기타 참고 사항
추가로 리뷰어가 참고해야 할 사항이 있다면 적어주세요.

-테스트 결과 
https://www.notion.so/25c058b1ded880e3a833fe9a9a43cf2b?source=copy_link
