### PR TITLE
refactor(profile): mainBadge 필드를 badges 리스트로 변경 및 조회 로직 수정 DP-307

### DIFF
--- a/src/main/java/goorm/ddok/player/controller/ProfileQueryController.java
+++ b/src/main/java/goorm/ddok/player/controller/ProfileQueryController.java
@@ -51,7 +51,10 @@ public class ProfileQueryController {
                     "ageGroup": "20대",
                     "mainPosition": "backend",
                     "subPositions": ["frontend", "devops"],
-                    "mainBadge": { "type": "login", "tier": "bronze" },
+                    "badges": [
+                      { "type": "login","tier": "bronze" },
+                      { "type": "comlpete","tier": "silver" },
+                    ],
                     "abandonBadge": { "isGranted": true, "count": 5 },
                     "activeHours": { "start": "19", "end": "23" },
                     "traits": ["정리의 신", "실행력 갓", "내향인"],

--- a/src/main/java/goorm/ddok/player/dto/response/ProfileDetailResponse.java
+++ b/src/main/java/goorm/ddok/player/dto/response/ProfileDetailResponse.java
@@ -54,8 +54,8 @@ public class ProfileDetailResponse {
     @Schema(description = "서브 포지션 목록", example = "[\"frontend\", \"devops\"]")
     private List<String> subPositions;
 
-    @Schema(description = "대표 배지")
-    private BadgeDto mainBadge;
+    @Schema(description = "보유 뱃지 목록")
+    private List<BadgeDto> badges;
 
     @Schema(description = "탈주 배지 정보")
     private AbandonBadgeDto abandonBadge;

--- a/src/main/java/goorm/ddok/player/service/ProfileQueryService.java
+++ b/src/main/java/goorm/ddok/player/service/ProfileQueryService.java
@@ -51,7 +51,7 @@ public class ProfileQueryService {
                     .nickname(user.getNickname())
                     .temperature(findTemperature(user))
                     .ageGroup(user.getAgeGroup())
-                    .mainBadge(toBadgeDto(user))
+                    .badges(toBadgeDto(user))
                     .content(user.getIntroduce())
                     .build();
         }
@@ -69,7 +69,7 @@ public class ProfileQueryService {
                 .ageGroup(user.getAgeGroup())
                 .mainPosition(findMainPosition(user))
                 .subPositions(findSubPositions(user))
-                .mainBadge(toBadgeDto(user))
+                .badges(toBadgeDto(user))
                 .abandonBadge(toAbandonBadgeDto(user))
                 .activeHours(toActiveHours(user.getActivity()))
                 .traits(findTraits(user))
@@ -132,9 +132,13 @@ public class ProfileQueryService {
         );
     }
 
-    private BadgeDto toBadgeDto(User user) {
-        // TODO: 대표 뱃지 조회 로직 구현
-        return new BadgeDto("login", "bronze");
+    private List<BadgeDto> toBadgeDto(User user) {
+        // TODO: User 엔티티에 뱃지 매핑된 엔티티 있으면 거기서 가져오기
+        // 지금은 임시 데이터로 세팅
+        return List.of(
+                new BadgeDto("login", "bronze"),
+                new BadgeDto("comlpete", "silver")
+        );
     }
 
     private AbandonBadgeDto toAbandonBadgeDto(User user) {


### PR DESCRIPTION
## 🔀 PR 제목

- [Refactor] 프로필 조회 API mainBadge → badges 필드 변경 및 조회 로직 수정

---

## 📌 작업 내용 요약
어떤 작업을 했는지 간략히 설명해주세요.

- ProfileDetailResponse의 mainBadge 필드를 badges 리스트로 변경로그인 페이지 폼 구현 (이메일/비밀번호 입력)
- ProfileQueryService에서 뱃지 조회 로직 수정 → 보유한 전체 뱃지 반환하도록 개선
- ProfileQueryController Swagger 응답 예시 수정 (mainBadge → badges)

---

## ✅ 체크리스트
PR을 올리기 전에 아래 항목을 확인했나요?

- [x] 기능 요구사항을 모두 구현했나요?
- [x] 로컬에서 기능을 직접 테스트했나요?
- [x] 코드 컨벤션 및 스타일을 지켰나요?
- [x] 관련된 이슈에 연결했나요?

---

## 🔗 관련 이슈
`Closes #이슈번호` 또는 `Related to #이슈번호` 형태로 작성

- Closes #84 
- Related to #84 
---

## 📎 기타 참고 사항
추가로 리뷰어가 참고해야 할 사항이 있다면 적어주세요.

예시:
- API 명세 변경사항 포함됨
- 테스트 코드는 다음 PR에서 작성 예정
