### PR TITLE
Feature/dp 317 project participation read teamid

### DIFF
--- a/src/main/java/goorm/ddok/global/exception/ErrorCode.java
+++ b/src/main/java/goorm/ddok/global/exception/ErrorCode.java
@@ -33,6 +33,8 @@ public enum ErrorCode {
     INVALID_STUDY_TYPE(HttpStatus.BAD_REQUEST, "스터디 유형은 필수이며 올바른 값이어야 합니다."),
     INVALID_MAP_BOUNDS(HttpStatus.BAD_REQUEST, "잘못된 지도 경계값입니다."),
     REQUIRED_PARAMETER_MISSING(HttpStatus.BAD_REQUEST, "필수 파라미터가 누락되었습니다."),
+    TEAM_NOT_FOUND(HttpStatus.NOT_FOUND, "팀 정보를 찾을 수 없습니다."),
+
 
     // 401 UNAUTHORIZED
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증이 필요합니다."),

--- a/src/main/java/goorm/ddok/player/controller/ProfileProjectQueryController.java
+++ b/src/main/java/goorm/ddok/player/controller/ProfileProjectQueryController.java
@@ -50,6 +50,7 @@ public class ProfileProjectQueryController {
                                         "items": [
                                           {
                                             "projectId": 1,
+                                            "teamId": 2,
                                             "title": "구지라지 프로젝트",
                                             "teamStatus": "CLOSED",
                                             "location": {
@@ -70,7 +71,12 @@ public class ProfileProjectQueryController {
                     content = @Content(schema = @Schema(implementation = ApiResponseDto.class),
                             examples = @ExampleObject(value = """
                                     { "status": 404, "message": "존재하지 않는 사용자입니다.", "data": null }
-                                    """)))
+                                    """))),
+            @ApiResponse(responseCode = "404", description = "팀 정보 없음",
+                    content = @Content(schema = @Schema(implementation = ApiResponseDto.class),
+                            examples = @ExampleObject(value = """
+                                { "status": 404, "message": "팀 정보를 찾을 수 없습니다.", "data": null }
+                                """)))
     })
     @GetMapping("/{userId}/profile/projects")
     public ResponseEntity<ApiResponseDto<?>> getUserProjects(

--- a/src/main/java/goorm/ddok/player/dto/response/ProjectParticipationResponse.java
+++ b/src/main/java/goorm/ddok/player/dto/response/ProjectParticipationResponse.java
@@ -45,7 +45,7 @@ public class ProjectParticipationResponse {
     @Schema(description = "프로젝트 제목", example = "구지라지 프로젝트")
     private String title;
 
-    @Schema(description = "팀 상태 (RECRUITING / ONGOING / CLOSED)", example = "CLOSED")
+    @Schema(description = "팀 상태 (ONGOING / CLOSED)", example = "CLOSED")
     private TeamStatus teamStatus;
 
     @Schema(description = "프로젝트 위치 정보")

--- a/src/main/java/goorm/ddok/player/dto/response/ProjectParticipationResponse.java
+++ b/src/main/java/goorm/ddok/player/dto/response/ProjectParticipationResponse.java
@@ -19,6 +19,7 @@ import lombok.NoArgsConstructor;
         example = """
         {
           "projectId": 1,
+          "teamId": 2,
           "title": "구지라지 프로젝트",
           "teamStatus": "CLOSED",
           "location": {
@@ -38,6 +39,9 @@ public class ProjectParticipationResponse {
     @Schema(description = "프로젝트 ID", example = "1")
     private Long projectId;
 
+    @Schema(description = "팀 ID", example = "2")
+    private Long teamId;
+
     @Schema(description = "프로젝트 제목", example = "구지라지 프로젝트")
     private String title;
 
@@ -47,18 +51,19 @@ public class ProjectParticipationResponse {
     @Schema(description = "프로젝트 위치 정보")
     private ProjectLocationResponse location;
 
-    @Schema(description = "모집 기간 (시작일 ~ 종료일)")
-    private ProjectPeriodResponse projectPeriod;
+    @Schema(description = "진행 기간 (시작일 ~ 종료일)")
+    private ProjectPeriodResponse period;
 
-    public static ProjectParticipationResponse from(ProjectParticipant participant) {
+    public static ProjectParticipationResponse from(ProjectParticipant participant, Long teamId) {
         ProjectRecruitment project = participant.getPosition().getProjectRecruitment();
 
         return ProjectParticipationResponse.builder()
                 .projectId(project.getId())
+                .teamId(teamId)
                 .title(project.getTitle())
                 .teamStatus(project.getTeamStatus())
                 .location(ProjectLocationResponse.from(project))
-                .projectPeriod(ProjectPeriodResponse.from(
+                .period(ProjectPeriodResponse.from(
                         project.getStartDate(),
                         project.getExpectedMonths(),
                         project.getTeamStatus()

--- a/src/main/java/goorm/ddok/player/service/ProfileProjectQueryService.java
+++ b/src/main/java/goorm/ddok/player/service/ProfileProjectQueryService.java
@@ -5,7 +5,11 @@ import goorm.ddok.global.exception.GlobalException;
 import goorm.ddok.member.repository.UserRepository;
 import goorm.ddok.player.dto.response.ProjectParticipationResponse;
 import goorm.ddok.project.domain.ProjectParticipant;
+import goorm.ddok.project.domain.ProjectRecruitment;
 import goorm.ddok.project.repository.ProjectParticipantRepository;
+import goorm.ddok.team.domain.Team;
+import goorm.ddok.team.domain.TeamType;
+import goorm.ddok.team.repository.TeamRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -20,6 +24,7 @@ public class ProfileProjectQueryService {
 
     private final ProjectParticipantRepository projectParticipantRepository;
     private final UserRepository userRepository;
+    private final TeamRepository teamRepository;
 
     public Page<ProjectParticipationResponse> getUserProjects(Long userId, int page, int size) {
         if (!userRepository.existsById(userId)) {
@@ -31,6 +36,16 @@ public class ProfileProjectQueryService {
         Page<ProjectParticipant> participations =
                 projectParticipantRepository.findByUser_IdAndDeletedAtIsNull(userId, pageable);
 
-        return participations.map(ProjectParticipationResponse::from);
+        return participations.map(p -> {
+            ProjectRecruitment recruitment = p.getPosition().getProjectRecruitment();
+
+            Long teamId = teamRepository
+                    .findByRecruitmentIdAndType(recruitment.getId(), TeamType.PROJECT)
+                    .map(Team::getId)
+                    .orElseThrow(() -> new GlobalException(ErrorCode.TEAM_NOT_FOUND));
+
+            return ProjectParticipationResponse.from(p, teamId);
+                }
+        );
     }
 }

--- a/src/main/java/goorm/ddok/player/service/ProfileProjectQueryService.java
+++ b/src/main/java/goorm/ddok/player/service/ProfileProjectQueryService.java
@@ -6,6 +6,7 @@ import goorm.ddok.member.repository.UserRepository;
 import goorm.ddok.player.dto.response.ProjectParticipationResponse;
 import goorm.ddok.project.domain.ProjectParticipant;
 import goorm.ddok.project.domain.ProjectRecruitment;
+import goorm.ddok.project.domain.TeamStatus;
 import goorm.ddok.project.repository.ProjectParticipantRepository;
 import goorm.ddok.team.domain.Team;
 import goorm.ddok.team.domain.TeamType;
@@ -34,9 +35,10 @@ public class ProfileProjectQueryService {
         Pageable pageable = PageRequest.of(page, size);
 
         Page<ProjectParticipant> participations =
-                projectParticipantRepository.findByUser_IdAndDeletedAtIsNull(userId, pageable);
+                projectParticipantRepository.findByUser_IdAndDeletedAtIsNullAndPosition_ProjectRecruitment_TeamStatusNot(userId, TeamStatus.RECRUITING, pageable);
 
-        return participations.map(p -> {
+        return participations
+                .map(p -> {
             ProjectRecruitment recruitment = p.getPosition().getProjectRecruitment();
 
             Long teamId = teamRepository

--- a/src/main/java/goorm/ddok/project/repository/ProjectParticipantRepository.java
+++ b/src/main/java/goorm/ddok/project/repository/ProjectParticipantRepository.java
@@ -43,7 +43,11 @@ public interface ProjectParticipantRepository extends JpaRepository<ProjectParti
     List<ProjectParticipant> findByPosition_ProjectRecruitment(ProjectRecruitment recruitment);
 
     /**
-     * 특정 사용자(userId)가 참여한 프로젝트 목록 조회 (Soft Delete 제외)
+     * 특정 사용자(userId)가 참여한 프로젝트 목록 조회 (Soft Delete 제외, 모집중(RECRUITING) 제외)
      */
-    Page<ProjectParticipant> findByUser_IdAndDeletedAtIsNull(Long userId, Pageable pageable);
+    Page<ProjectParticipant> findByUser_IdAndDeletedAtIsNullAndPosition_ProjectRecruitment_TeamStatusNot(
+            Long userId,
+            goorm.ddok.project.domain.TeamStatus status,
+            Pageable pageable
+    );
 }

--- a/src/main/java/goorm/ddok/team/repository/TeamRepository.java
+++ b/src/main/java/goorm/ddok/team/repository/TeamRepository.java
@@ -1,7 +1,13 @@
 package goorm.ddok.team.repository;
 
 import goorm.ddok.team.domain.Team;
+import goorm.ddok.team.domain.TeamType;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface TeamRepository extends JpaRepository<Team, Long> {
+
+    Optional<Team> findByRecruitmentIdAndType(Long recruitmentId, TeamType type);
+
 }


### PR DESCRIPTION
## 🔀 PR 제목
- [Feature] 참여 프로젝트 조회 API에 teamId 추가 및 RECRUITING 상태 제외

---

## 📌 작업 내용 요약
어떤 작업을 했는지 간략히 설명해주세요.

- `ProjectParticipationResponse` DTO에 teamId 필드 추가
- 참여 프로젝트 조회 시 TeamRepository를 통해 teamId 매핑
- `ProjectParticipantRepository`에 RECRUITING 상태 제외 조건 메서드 추가
- `ProfileProjectQueryService`에서 RECRUITING 상태 프로젝트는 조회되지 않도록 변경
- Swagger 문서(`ProfileProjectQueryController`)에 팀 정보 없음(TEAM_NOT_FOUND) 예외 스키마 추가
---

## ✅ 체크리스트
PR을 올리기 전에 아래 항목을 확인했나요?

- [x] 기능 요구사항을 모두 구현했나요?
- [x] 로컬에서 기능을 직접 테스트했나요?
- [x] 코드 컨벤션 및 스타일을 지켰나요?
- [x] 관련된 이슈에 연결했나요?

---

## 🔗 관련 이슈
`Closes #이슈번호` 또는 `Related to #이슈번호` 형태로 작성

- Closes #102 
- Related to #102 
---

## 📎 기타 참고 사항
추가로 리뷰어가 참고해야 할 사항이 있다면 적어주세요.

- `StudyParticipationResponse`에는 아직 동일 로직 미적용 (추후 별도 이슈에서 진행 예정)
