### PR TITLE
[Feature] 개인정보 수정 시 비밀번호 검증 기능 구현

### DIFF
--- a/src/main/java/goorm/ddok/global/config/SwaggerConfig.java
+++ b/src/main/java/goorm/ddok/global/config/SwaggerConfig.java
@@ -18,9 +18,16 @@ public class SwaggerConfig {
     private OpenAPI base() {
         return new OpenAPI()
                 .info(new Info().title("DDOK API").description("DDOK 프로젝트 REST API 문서").version("v1"))
-                .components(new Components().addSecuritySchemes(
-                        SECURITY_SCHEME_NAME, new SecurityScheme().name(SECURITY_SCHEME_NAME)
-                                .type(SecurityScheme.Type.HTTP).scheme("bearer").bearerFormat("JWT")))
+                .components(new Components()
+                        .addSecuritySchemes("Authorization",
+                                new SecurityScheme().name("Authorization")
+                                        .type(SecurityScheme.Type.HTTP)
+                                        .scheme("bearer")
+                                        .bearerFormat("JWT"))
+                        .addSecuritySchemes("Reauth",
+                                new SecurityScheme().name("X-Reauth-Token")
+                                        .in(SecurityScheme.In.HEADER)
+                                        .type(SecurityScheme.Type.APIKEY)))
                 .addSecurityItem(new SecurityRequirement().addList(SECURITY_SCHEME_NAME));
     }
 

--- a/src/main/java/goorm/ddok/global/config/WebMvcConfig.java
+++ b/src/main/java/goorm/ddok/global/config/WebMvcConfig.java
@@ -1,0 +1,21 @@
+package goorm.ddok.global.config;
+
+import goorm.ddok.global.security.token.ReauthRequiredInterceptor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebMvcConfig implements WebMvcConfigurer {
+
+    private final ReauthRequiredInterceptor reauthRequiredInterceptor;
+
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(reauthRequiredInterceptor)
+                .addPathPatterns("/api/me/**");
+    }
+}

--- a/src/main/java/goorm/ddok/global/exception/ErrorCode.java
+++ b/src/main/java/goorm/ddok/global/exception/ErrorCode.java
@@ -64,12 +64,16 @@ public enum ErrorCode {
     WRONG_PASSWORD(HttpStatus.UNAUTHORIZED, "아이디 혹은 비밀번호가 일치하지 않습니다."),
     SOCIAL_LOGIN_FAILED(HttpStatus.UNAUTHORIZED, "카카오 로그인에 실패했습니다"),
     POSITION_REQUIRED(HttpStatus.BAD_REQUEST, "지원 포지션을 선택해야 합니다."),
+    PASSWORD_MISMATCH(HttpStatus.UNAUTHORIZED, "비밀번호가 일치하지 않습니다."),
+    REAUTH_REQUIRED(HttpStatus.UNAUTHORIZED, "재인증이 필요합니다."),
+    INVALID_REAUTH_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 재인증 토큰입니다."),
 
 
     // 403 FORBIDDEN
     FORBIDDEN(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
     NOT_CHAT_MEMBER(HttpStatus.FORBIDDEN, "채팅방에 참여하지 않은 사용자입니다."),
     FORBIDDEN_ACTION(HttpStatus.FORBIDDEN, "리더는 참여 신청을 할 수 없습니다."),
+    REAUTH_USER_MISMATCH(HttpStatus.FORBIDDEN, "재인증 사용자 정보가 일치하지 않습니다."),
 
 
     // 404 NOT FOUND

--- a/src/main/java/goorm/ddok/global/security/token/CustomReauthTokenService.java
+++ b/src/main/java/goorm/ddok/global/security/token/CustomReauthTokenService.java
@@ -15,7 +15,7 @@ public class CustomReauthTokenService {
 
     private static final String KEY_PREFIX = "reauth:";
     private final StringRedisTemplate redis;
-    private final Duration ttl = Duration.ofMinutes(10);
+    private final Duration ttl = Duration.ofMinutes(30);
 
     public String issue(Long userId) {
         String token = "reauth_" + UUID.randomUUID().toString().replace("-", "");

--- a/src/main/java/goorm/ddok/global/security/token/CustomReauthTokenService.java
+++ b/src/main/java/goorm/ddok/global/security/token/CustomReauthTokenService.java
@@ -15,7 +15,7 @@ public class CustomReauthTokenService {
 
     private static final String KEY_PREFIX = "reauth:";
     private final StringRedisTemplate redis;
-    private final Duration ttl = Duration.ofMinutes(5);
+    private final Duration ttl = Duration.ofMinutes(10);
 
     public String issue(Long userId) {
         String token = "reauth_" + UUID.randomUUID().toString().replace("-", "");

--- a/src/main/java/goorm/ddok/global/security/token/CustomReauthTokenService.java
+++ b/src/main/java/goorm/ddok/global/security/token/CustomReauthTokenService.java
@@ -1,0 +1,40 @@
+package goorm.ddok.global.security.token;
+
+import goorm.ddok.global.exception.ErrorCode;
+import goorm.ddok.global.exception.GlobalException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class CustomReauthTokenService {
+
+    private static final String KEY_PREFIX = "reauth:";
+    private final StringRedisTemplate redis;
+    private final Duration ttl = Duration.ofMinutes(5);
+
+    public String issue(Long userId) {
+        String token = "reauth_" + UUID.randomUUID().toString().replace("-", "");
+        String key = KEY_PREFIX + token;
+        redis.opsForValue().set(key, String.valueOf(userId), ttl);
+        return token;
+    }
+
+    public void validate(String token, Long expectedUserId) {
+        if (token == null || token.isBlank()) {
+            throw new GlobalException(ErrorCode.REAUTH_REQUIRED);
+        }
+        String key = KEY_PREFIX + token;
+        String val = redis.opsForValue().get(key);
+        if (val == null) {
+            throw new GlobalException(ErrorCode.INVALID_REAUTH_TOKEN);
+        }
+        if (!val.equals(String.valueOf(expectedUserId))) {
+            throw new GlobalException(ErrorCode.REAUTH_USER_MISMATCH);
+        }
+    }
+}

--- a/src/main/java/goorm/ddok/global/security/token/ReauthRequired.java
+++ b/src/main/java/goorm/ddok/global/security/token/ReauthRequired.java
@@ -1,0 +1,8 @@
+package goorm.ddok.global.security.token;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface ReauthRequired { }

--- a/src/main/java/goorm/ddok/global/security/token/ReauthRequiredInterceptor.java
+++ b/src/main/java/goorm/ddok/global/security/token/ReauthRequiredInterceptor.java
@@ -1,0 +1,51 @@
+package goorm.ddok.global.security.token;
+
+import goorm.ddok.global.exception.ErrorCode;
+import goorm.ddok.global.exception.GlobalException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+@Component
+@RequiredArgsConstructor
+public class ReauthRequiredInterceptor implements HandlerInterceptor {
+
+    public static final String HEADER = "X-Reauth-Token";
+
+    private final CustomReauthTokenService customReauthTokenService;
+
+    @Override
+    public boolean preHandle(@NotNull HttpServletRequest request, @NotNull HttpServletResponse response, @NotNull Object handler) {
+        if (!(handler instanceof HandlerMethod hm)) return true;
+
+        // 메서드나 타입에 @ReauthRequired 있으면 검사
+        boolean required = hm.hasMethodAnnotation(ReauthRequired.class)
+                || hm.getBeanType().isAnnotationPresent(ReauthRequired.class);
+
+        if (!required) return true;
+
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth == null || !auth.isAuthenticated()) {
+            throw new GlobalException(ErrorCode.UNAUTHORIZED);
+        }
+
+        Object principal = auth.getPrincipal();
+        Long userId;
+
+        if (principal instanceof goorm.ddok.global.security.auth.CustomUserDetails cud) {
+            userId = cud.getId();
+        } else {
+            throw new GlobalException(ErrorCode.UNAUTHORIZED);
+        }
+
+        String token = request.getHeader(HEADER);
+        customReauthTokenService.validate(token, userId);
+        return true;
+    }
+}

--- a/src/main/java/goorm/ddok/member/controller/AuthController.java
+++ b/src/main/java/goorm/ddok/member/controller/AuthController.java
@@ -451,6 +451,11 @@ public class AuthController {
             summary = "개인화 설정 생성",
             description = "대표/관심 포지션, 기술스택, 위치, 특성, 생년월일, 활동시간을 등록합니다.",
             security = @SecurityRequirement(name = "Authorization"),
+            parameters = {
+                    @Parameter(name = "Authorization", in = ParameterIn.HEADER, required = true,
+                            description = "Bearer {accessToken}",
+                            examples = @ExampleObject(value = "Bearer eyJhbGciOi..."))
+            },
             requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
                     required = true,
                     content = @Content(

--- a/src/main/java/goorm/ddok/member/controller/TechStackSearchController.java
+++ b/src/main/java/goorm/ddok/member/controller/TechStackSearchController.java
@@ -35,7 +35,12 @@ public class TechStackSearchController {
     @Operation(
             summary = "기술 스택 검색",
             description = "키워드로 기술 스택을 검색합니다. (as-you-type + 오타 허용)",
-            security = @SecurityRequirement(name = "Authorization")
+            security = @SecurityRequirement(name = "Authorization"),
+            parameters = {
+                    @Parameter(name = "Authorization", in = ParameterIn.HEADER, required = true,
+                            description = "Bearer {accessToken}",
+                            examples = @ExampleObject(value = "Bearer eyJhbGciOi..."))
+            }
     )
     @ApiResponses(value = {
             @ApiResponse(

--- a/src/main/java/goorm/ddok/member/dto/request/PasswordVerifyRequest.java
+++ b/src/main/java/goorm/ddok/member/dto/request/PasswordVerifyRequest.java
@@ -1,0 +1,36 @@
+package goorm.ddok.member.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(
+        name = "PasswordVerifyRequest",
+        description = "비밀번호 인증 요청 DTO",
+        requiredProperties = "password",
+        example = """
+    {
+      "password": "1Q2w3e4r!@#"
+    }
+    """
+)
+public class PasswordVerifyRequest {
+    @NotBlank(message = "비밀번호 입력이 누락되었습니다.")
+    @Schema(
+            description = "비밀번호",
+            example = "1Q2w3e4r!@#",
+            type = "string",
+            format = "password",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
+    @Size(min = 8, max = 72)
+    private String password;
+}

--- a/src/main/java/goorm/ddok/member/dto/response/PasswordVerifyResponse.java
+++ b/src/main/java/goorm/ddok/member/dto/response/PasswordVerifyResponse.java
@@ -1,0 +1,23 @@
+package goorm.ddok.member.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Schema(
+        name = "PasswordVerifResponse",
+        description = "비밀번호 인증 및 reauthToken 발급 응답 DTO",
+        example = """
+    { "reauthToken": "REAUTH_TOKEN_VALUE" }
+    """
+)
+public class PasswordVerifyResponse {
+    @Schema(
+            description = "재인증 토큰",
+            example = "REAUTH_TOKEN_VALUE",
+            accessMode = Schema.AccessMode.READ_ONLY
+    )
+    private String reauthToken;
+}


### PR DESCRIPTION
## 🔀 PR 제목

- [Feature] 개인정보 수정 시 비밀번호 검증 기능 구현

---

## 📌 작업 내용 요약
어떤 작업을 했는지 간략히 설명해주세요.

- 비밀번호 검증 API 추가
  - POST /api/me/settings (JSON: {"password":"..."} ) → reauthToken 발급
  - 성공 응답: {"status":200,"message":"본인 인증에 성공했습니다.","data":{"reauthToken":"..."} }

- 민감 API에 reauthToken 요구
  - 헤더 X-Reauth-Token: {reauthToken} 필수
  - 대상 엔드포인트
      - PATCH /api/me/settings/image (JSON, multipart 둘 다)
      - PATCH /api/me/settings/nickname
      - PATCH /api/me/settings/phone
      - DELETE /api/me/settings

- Reauth 토큰 관리
    - ReauthTokenService 도입 (Redis 기반, 기본 TTL 10분, 환경설정으로 조정 가능)
    - 사용자별 토큰 바인딩 및 유효성 검증

- 보안/문서화
    - @ReauthRequired 어노테이션 + ReauthRequiredInterceptor로 공통 검증
    - Swagger 보안 스키마 추가
        - Bearer Authorization(JWT)
        - API Key X-Reauth-Token
    - 각 민감 API에 X-Reauth-Token 헤더 파라미터 명시
    
- 에러 코드 추가
  - REAUTH_REQUIRED, INVALID_REAUTH_TOKEN, REAUTH_USER_MISMATCH, PASSWORD_MISMATCH
  
- 서비스 레이어
    - MeSettingsService.verifyPasswordAndIssueReauthToken(...) 추가
    - 기존 프로필/닉네임/전화번호/탈퇴 로직은 변경 없이 reauth 검증만 추가

---

## ✅ 체크리스트
PR을 올리기 전에 아래 항목을 확인했나요?

- [ ] 기능 요구사항을 모두 구현했나요?
- [ ] 로컬에서 기능을 직접 테스트했나요?
- [ ] 코드 컨벤션 및 스타일을 지켰나요?
- [ ] 관련된 이슈에 연결했나요?

---

## 🔗 관련 이슈

- Closes #125 

---

## 📎 기타 참고 사항
추가로 리뷰어가 참고해야 할 사항이 있다면 적어주세요.

<img width="1022" height="591" alt="스크린샷 2025-09-05 오전 6 11 03" src="https://github.com/user-attachments/assets/e0bdbbf0-5ce7-40e7-b105-199f60bf25b9" />

<img width="1172" height="757" alt="스크린샷 2025-09-05 오전 6 11 12" src="https://github.com/user-attachments/assets/a69b0032-a129-43e9-a038-e715698fe371" />

