### PR TITLE
[Feature] 핀 오버레이 및 프로필 지도 api

### DIFF
--- a/src/main/java/goorm/ddok/global/exception/ErrorCode.java
+++ b/src/main/java/goorm/ddok/global/exception/ErrorCode.java
@@ -53,6 +53,8 @@ public enum ErrorCode {
     INVALID_FILE(HttpStatus.BAD_REQUEST, "부적절한 파일입니다."),
     FILE_TOO_LARGE(HttpStatus.BAD_REQUEST, "파일 크기는 5MB를 넘을 수 없습니다."),
     FILE_UPLOAD_FAILED(HttpStatus.BAD_REQUEST, "파일 업로드에 실패하였습니다."),
+    RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "리소스를 찾을 수 없습니다."),
+    NOT_SUPPORT_CATEGORY(HttpStatus.BAD_REQUEST, "지원하지 않는 카테고리입니다."),
 
     // 401 UNAUTHORIZED
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증이 필요합니다."),

--- a/src/main/java/goorm/ddok/map/controller/MapOverlayController.java
+++ b/src/main/java/goorm/ddok/map/controller/MapOverlayController.java
@@ -1,0 +1,44 @@
+package goorm.ddok.map.controller;
+
+import goorm.ddok.global.response.ApiResponseDto;
+import goorm.ddok.global.security.auth.CustomUserDetails;
+import goorm.ddok.map.dto.response.PinOverlayResponse;
+import goorm.ddok.map.service.MapService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Map", description = "지도 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/map")
+public class MapOverlayController {
+
+    private final MapService mapService;
+
+    @Operation(
+            summary = "핀 오버레이 정보 조회",
+            description = """
+            category: project|study|cafe|player
+            - 각 카테고리별로 필드가 다릅니다.
+            - 인증 사용 시 player.isMine 계산에 활용됩니다.
+            """
+    )
+    @GetMapping("/overlay/{category}/{id}")
+    public ResponseEntity<ApiResponseDto<PinOverlayResponse>> getOverlay(
+            @Parameter(description = "카테고리", example = "project") @PathVariable String category,
+            @Parameter(description = "리소스 ID", example = "1")   @PathVariable Long id,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        Long currentUserId = (userDetails != null) ? userDetails.getId() : null;
+        PinOverlayResponse data = mapService.getOverlay(category, id, currentUserId);
+        return ResponseEntity.ok(ApiResponseDto.of(200, "핀 오버레이 정보 조회에 성공하였습니다.", data));
+    }
+}

--- a/src/main/java/goorm/ddok/map/controller/MapOverlayController.java
+++ b/src/main/java/goorm/ddok/map/controller/MapOverlayController.java
@@ -6,6 +6,11 @@ import goorm.ddok.map.dto.response.PinOverlayResponse;
 import goorm.ddok.map.service.MapService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -31,6 +36,118 @@ public class MapOverlayController {
             - 인증 사용 시 player.isMine 계산에 활용됩니다.
             """
     )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "성공",
+                    content = @Content(schema = @Schema(implementation = ApiResponseDto.class),
+                            examples = @ExampleObject(name = "성공 예시", value = """
+                    {
+                        "status": 200,
+                        "message": "핀 오버레이 정보 조회에 성공하였습니다.",
+                        "data": {
+                            "category": "player",
+                            "address": "전북 익산시",
+                            "userId": 1,
+                            "nickname": "요망한 백엔드",
+                            "profileImageUrl": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI0OCIgaGVpZ2h0PSI0OCI+CiAgPHJlY3Qgd2lkdGg9IjEwMCUiIGhlaWdodD0iMTAwJSIgZmlsbD0iI0Y1Q0JBNyIvPgogIDx0ZXh0IHg9IjUwJSIgeT0iNTUlIiBmb250LXNpemU9IjE1IiBmaWxsPSJibGFjayIgZm9udC13ZWlnaHQ9ImJvbGQiIHRleHQtYW5jaG9yPSJtaWRkbGUiIGRvbWluYW50LWJhc2VsaW5lPSJtaWRkbGUiIGZvbnQtZmFtaWx5PSJJbnRlciI+7JqU67CxPC90ZXh0Pgo8L3N2Zz4K",
+                            "mainPosition": "백엔드",
+                            "temperature": 36.5,
+                            "isMine": true,
+                            "mainBadge": {
+                                "type": "login",
+                                "tier": "bronze"
+                            },
+                            "abandonBadge": {
+                                "count": 5,
+                                "granted": true
+                            },
+                            "latestProject": {
+                                "id": 1,
+                                "title": "청년 창업 지원 포털",
+                                "teamStatus": "RECRUITING"
+                            },
+                            "latestStudy": {
+                                "id": 1,
+                                "title": "스프링 시큐리티 심화 스터디",
+                                "teamStatus": "RECRUITING"
+                            }
+                        }
+                    },
+                    {
+                        "status": 200,
+                        "message": "핀 오버레이 정보 조회에 성공하였습니다.",
+                        "data": {
+                            "category": "project",
+                            "address": "전북 익산시",
+                            "projectId": 1,
+                            "title": "청년 창업 지원 포털",
+                            "bannerImageUrl": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxMjAwIiBoZWlnaHQ9IjYwMCI+CiAgPHJlY3Qgd2lkdGg9IjEwMCUiIGhlaWdodD0iMTAwJSIgZmlsbD0iI0ZGRTU5OSIvPgogIDx0ZXh0IHg9IjUwJSIgeT0iNTUlIiBmb250LXNpemU9IjgwIiBmaWxsPSJibGFjayIgZm9udC13ZWlnaHQ9ImJvbGQiCiAgICAgICAgdGV4dC1hbmNob3I9Im1pZGRsZSIgZG9taW5hbnQtYmFzZWxpbmU9Im1pZGRsZSIgZm9udC1mYW1pbHk9IkludGVyIj7ssq3rhYQg7LC97JeFIOyngOybkCDtj6zthLg8L3RleHQ+Cjwvc3ZnPgo=",
+                            "teamStatus": "RECRUITING",
+                            "capacity": 7,
+                            "mode": "offline",
+                            "preferredAges": {
+                                "ageMin": 20,
+                                "ageMax": 40
+                            },
+                            "expectedMonth": 6,
+                            "startDate": "2025-11-03",
+                            "positions": [
+                                "백엔드",
+                                "프론트엔드",
+                                "디자이너",
+                                "PM"
+                            ]
+                        }
+                    },
+                    {
+                        "status": 200,
+                        "message": "핀 오버레이 정보 조회에 성공하였습니다.",
+                        "data": {
+                            "category": "study",
+                            "address": "전북 익산시",
+                            "studyId": 1,
+                            "title": "스프링 시큐리티 심화 스터디",
+                            "bannerImageUrl": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxMjAwIiBoZWlnaHQ9IjYwMCI+CiAgPHJlY3Qgd2lkdGg9IjEwMCUiIGhlaWdodD0iMTAwJSIgZmlsbD0iI0Y1Q0JBNyIvPgogIDx0ZXh0IHg9IjUwJSIgeT0iNTUlIiBmb250LXNpemU9IjgwIiBmaWxsPSJibGFjayIgZm9udC13ZWlnaHQ9ImJvbGQiCiAgICAgICAgdGV4dC1hbmNob3I9Im1pZGRsZSIgZG9taW5hbnQtYmFzZWxpbmU9Im1pZGRsZSIgZm9udC1mYW1pbHk9IkludGVyIj7siqTtlITrp4Eg7Iuc7YGQ66as7YuwIOyLrO2ZlCDsiqTthLDrlJQ8L3RleHQ+Cjwvc3ZnPgo=",
+                            "teamStatus": "RECRUITING",
+                            "mode": "offline",
+                            "preferredAges": {
+                                "ageMin": 20,
+                                "ageMax": 40
+                            },
+                            "expectedMonth": 2,
+                            "startDate": "2025-10-15",
+                            "studyType": "취업/면접"
+                        }
+                    },
+                    {
+                        "status": 200,
+                        "message": "핀 오버레이 정보 조회에 성공하였습니다.",
+                        "data": {
+                            "category": "cafe",
+                            "address": "서울 강남구",
+                            "cafeId": 1,
+                            "title": "룸카페 바니",
+                            "bannerImageUrl": "",
+                            "rating": 2,
+                            "reviewCount": 4
+                        }
+                    }
+                    """))),
+            @ApiResponse(responseCode = "400", description = "지원하지 않는 카테고리",
+                    content = @Content(schema = @Schema(implementation = ApiResponseDto.class),
+                            examples = @ExampleObject(name = "지원하지 않는 카테고리", value = """
+                    { "status": 400, "message": "지원하지 않는 카테고리입니다.", "data": null }
+                    """))),
+            @ApiResponse(responseCode = "400", description = "필수 파라미터 누락",
+                    content = @Content(schema = @Schema(implementation = ApiResponseDto.class),
+                            examples = @ExampleObject(name = "경계 오류 예시", value = """
+                    { "status": 400, "message": "필수 파라미터가 누락되었습니다.", "data": null }
+                    """))),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류",
+                    content = @Content(schema = @Schema(implementation = ApiResponseDto.class),
+                            examples = @ExampleObject(value = """
+                    { "status": 500, "message": "서버 내부 오류", "data": null }
+                    """)))
+    })
     @GetMapping("/overlay/{category}/{id}")
     public ResponseEntity<ApiResponseDto<PinOverlayResponse>> getOverlay(
             @Parameter(description = "카테고리", example = "project") @PathVariable String category,

--- a/src/main/java/goorm/ddok/map/dto/response/PinOverlayResponse.java
+++ b/src/main/java/goorm/ddok/map/dto/response/PinOverlayResponse.java
@@ -106,7 +106,7 @@ public class PinOverlayResponse {
     private BigDecimal temperature;
 
     @Schema(description = "내 프로필 여부 (category='player'일 때)", example = "true", nullable = true)
-    private boolean IsMine;
+    private final Boolean isMine;
 
     @Schema(description = "메인 뱃지 (category='player'일 때)", nullable = true)
     private final MainBadge mainBadge;

--- a/src/main/java/goorm/ddok/map/dto/response/PinOverlayResponse.java
+++ b/src/main/java/goorm/ddok/map/dto/response/PinOverlayResponse.java
@@ -1,0 +1,163 @@
+package goorm.ddok.map.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import goorm.ddok.global.dto.PreferredAgesDto;
+import goorm.ddok.project.domain.ProjectMode;
+import goorm.ddok.project.domain.TeamStatus;
+import goorm.ddok.study.domain.StudyType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Schema(name = "PinOverlayResponse", description = "지도 핀 오버레이 응답")
+public class PinOverlayResponse {
+
+    /* =========================
+     *  공통 필드
+     * ========================= */
+    @Schema(description = "카테고리", example = "project", allowableValues = {"project", "study", "cafe", "player"})
+    private final String category;
+
+    @Schema(description = "주소", example = "서울 강남구")
+    private final String address;
+
+    /* =========================
+     *  ID 필드 (카테고리별)
+     * ========================= */
+    @Schema(description = "프로젝트 ID (category='project'일 때)", nullable = true)
+    private final Long projectId;
+
+    @Schema(description = "스터디 ID (category='study'일 때)", nullable = true)
+    private final Long studyId;
+
+    @Schema(description = "카페 ID (category='cafe'일 때)", nullable = true)
+    private final Long cafeId;
+
+    @Schema(description = "사용자 ID (category='player'일 때)", nullable = true)
+    private final Long userId;
+
+    /* =========================
+     *  프로젝트/스터디 공통 필드
+     * ========================= */
+    @Schema(description = "공고 제목", example = "구지라지")
+    private String title;
+
+    @Schema(description = "배너 이미지 URL", example = "https://cdn.example.com/images/default.png")
+    private String bannerImageUrl;
+
+    @Schema(description = "팀 상태", example = "RECRUITING")
+    private String teamStatus;
+
+    @Schema(description = "모집 정원", example = "6")
+    private Integer capacity;
+
+    @Schema(description = "진행 방식", example = "offline")
+    private ProjectMode mode;
+
+    @Schema(description = "선호 연령대 (무관이면 null)", nullable = true)
+    private PreferredAgesDto preferredAges;
+
+    @Schema(description = "예상 진행 개월 수", example = "3")
+    private Integer expectedMonth;
+
+    @Schema(description = "시작 예정일", example = "2025-09-16")
+    private LocalDate startDate;
+
+
+    /* =========================
+     *  프로젝트 전용 필드
+     * ========================= */
+    @Schema(description = "모집 포지션 리스트", example = "[\"백엔드\", \"프론트엔드\", \"디자이너\"]")
+    private List<String> positions;
+
+    /* =========================
+     *  스터디 전용 필드
+     * ========================= */
+    @Schema(description = "스터디 유형 (category='study'일 때)", example = "JOB_INTERVIEW", nullable = true)
+    private StudyType studyType;
+
+    /* =========================
+     *  카페 전용 필드
+     * ========================= */
+    @Schema(description = "평균 평점 (category='cafe'일 때)", example = "3.9", nullable = true)
+    private final BigDecimal rating;
+
+    @Schema(description = "후기 개수 (category='cafe'일 때)", example = "193", nullable = true)
+    private final Long reviewCount;
+
+    /* =========================
+     *  플레이어 전용 필드
+     * ========================= */
+    @Schema(description = "닉네임 (category='player'일 때)", example = "똑똑한 똑똑이", nullable = true)
+    private String nickname;
+
+    @Schema(description = "프로필 이미지 URL (category='player'일 때)", example = "https://cdn.example.com/profile.png", nullable = true)
+    private String profileImageUrl;
+
+    @Schema(description = "메인 포지션 (category='player'일 때)", example = "backend", nullable = true)
+    private String mainPosition;
+
+    @Schema(description = "온도 (category='player'일 때)", example = "36.6", nullable = true)
+    private BigDecimal temperature;
+
+    @Schema(description = "내 프로필 여부 (category='player'일 때)", example = "true", nullable = true)
+    private boolean IsMine;
+
+    @Schema(description = "메인 뱃지 (category='player'일 때)", nullable = true)
+    private final MainBadge mainBadge;
+
+    @Schema(description = "탈주 뱃지 (category='player'일 때)", nullable = true)
+    private final AbandonBadge abandonBadge;
+
+    @Schema(description = "최근 참여 프로젝트 (category='player'일 때)", nullable = true)
+    private final MiniItem latestProject;
+
+    @Schema(description = "최근 참여 스터디 (category='player'일 때)", nullable = true)
+    private final MiniItem latestStudy;
+
+    /* =========================
+     *  내부 클래스
+     * ========================= */
+    @Getter
+    @Builder
+    @Schema(description = "메인 뱃지 정보")
+    public static class MainBadge {
+        @Schema(description = "뱃지 타입", example = "login")
+        private final String type;
+
+        @Schema(description = "뱃지 등급", example = "bronze")
+        private final String tier;
+    }
+
+    @Getter
+    @Builder
+    @Schema(description = "탈주 뱃지 정보")
+    public static class AbandonBadge {
+        @Schema(description = "뱃지 부여 여부", example = "false")
+        private final boolean isGranted;
+
+        @Schema(description = "포기 횟수", example = "0")
+        private final Integer count;
+    }
+
+    @Getter
+    @Builder
+    @Schema(description = "미니 아이템 정보")
+    public static class MiniItem {
+        @Schema(description = "ID", example = "1")
+        private final Long id;
+
+        @Schema(description = "제목", example = "React 스터디")
+        private final String title;
+
+        @Schema(description = "팀 상태", example = "RECRUITING")
+        private final String teamStatus;
+    }
+}

--- a/src/main/java/goorm/ddok/map/dto/response/PinOverlayResponse.java
+++ b/src/main/java/goorm/ddok/map/dto/response/PinOverlayResponse.java
@@ -2,8 +2,6 @@ package goorm.ddok.map.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import goorm.ddok.global.dto.PreferredAgesDto;
-import goorm.ddok.project.domain.ProjectMode;
-import goorm.ddok.project.domain.TeamStatus;
 import goorm.ddok.study.domain.StudyType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
@@ -59,7 +57,7 @@ public class PinOverlayResponse {
     private Integer capacity;
 
     @Schema(description = "진행 방식", example = "offline")
-    private ProjectMode mode;
+    private String mode;
 
     @Schema(description = "선호 연령대 (무관이면 null)", nullable = true)
     private PreferredAgesDto preferredAges;

--- a/src/main/java/goorm/ddok/map/service/MapService.java
+++ b/src/main/java/goorm/ddok/map/service/MapService.java
@@ -653,7 +653,7 @@ public class MapService {
         }
         switch (category.trim().toLowerCase()) {
             case "project": return getProjectOverlay(id);
-            // case "study": ...
+            case "study": return getStudyOverlay(id);
             // case "cafe": ...
             // case "player": ...
             default:
@@ -676,7 +676,30 @@ public class MapService {
                 .teamStatus(normalizeProjectTeamStatus(row.getTeamStatus()))
                 .positions(positions)
                 .capacity(row.getCapacity())
-                .mode(row.getMode())
+                .mode(row.getMode().toString())
+                .address(row.getAddress())
+                .preferredAges(PreferredAgesDto.builder()
+                        .ageMin(row.getAgeMin())
+                        .ageMax(row.getAgeMax())
+                        .build())
+                .expectedMonth(row.getExpectedMonth())
+                .startDate(row.getStartDate())
+                .build();
+    }
+
+    private PinOverlayResponse getStudyOverlay(Long id) {
+        var row = studyRecruitmentRepository.findOverlayById(id)
+                .orElseThrow(() -> new GlobalException(ErrorCode.RESOURCE_NOT_FOUND));
+
+        return PinOverlayResponse.builder()
+                .category("study")
+                .studyId(row.getId())
+                .title(row.getTitle())
+                .bannerImageUrl(row.getBannerImageUrl())
+                .teamStatus(normalizeStudyTeamStatus(row.getTeamStatus()))
+                .studyType(row.getStudyType())
+                .capacity(row.getCapacity())
+                .mode(row.getMode().toString())
                 .address(row.getAddress())
                 .preferredAges(PreferredAgesDto.builder()
                         .ageMin(row.getAgeMin())

--- a/src/main/java/goorm/ddok/map/service/MapService.java
+++ b/src/main/java/goorm/ddok/map/service/MapService.java
@@ -654,7 +654,7 @@ public class MapService {
         switch (category.trim().toLowerCase()) {
             case "project": return getProjectOverlay(id);
             case "study": return getStudyOverlay(id);
-            // case "cafe": ...
+            case "cafe":    return getCafeOverlay(id);
             // case "player": ...
             default:
                 throw new GlobalException(ErrorCode.NOT_SUPPORT_CATEGORY);
@@ -665,7 +665,6 @@ public class MapService {
         var row = projectRecruitmentRepository.findOverlayById(id)
                 .orElseThrow(() -> new GlobalException(ErrorCode.RESOURCE_NOT_FOUND));
 
-        // 포지션 CSV → 리스트
         List<String> positions = splitCsv(row.getPositionsCsv());
 
         return PinOverlayResponse.builder()
@@ -707,6 +706,21 @@ public class MapService {
                         .build())
                 .expectedMonth(row.getExpectedMonth())
                 .startDate(row.getStartDate())
+                .build();
+    }
+
+    private PinOverlayResponse getCafeOverlay(Long id) {
+        var row = cafeRepository.findOverlayById(id)
+                .orElseThrow(() -> new GlobalException(ErrorCode.RESOURCE_NOT_FOUND));
+
+        return PinOverlayResponse.builder()
+                .category("cafe")
+                .cafeId(row.getId())
+                .title(row.getName())
+                .bannerImageUrl(row.getBannerImageUrl())
+                .rating(row.getRating() == null ? java.math.BigDecimal.ZERO : row.getRating())
+                .reviewCount(row.getReviewCount() == null ? 0L : row.getReviewCount())
+                .address(row.getAddress())
                 .build();
     }
 

--- a/src/main/java/goorm/ddok/member/controller/PlayerProfileMapController.java
+++ b/src/main/java/goorm/ddok/member/controller/PlayerProfileMapController.java
@@ -3,7 +3,13 @@ package goorm.ddok.member.controller;
 import goorm.ddok.global.response.ApiResponseDto;
 import goorm.ddok.member.dto.response.PlayerProfileMapItemResponse;
 import goorm.ddok.member.service.PlayerProfileMapService;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.DecimalMax;
 import jakarta.validation.constraints.DecimalMin;
@@ -22,7 +28,76 @@ public class PlayerProfileMapController {
 
     private final PlayerProfileMapService playerProfileMapService;
 
-    @GetMapping("/{userId}/profile/map")
+    @Operation(
+            summary = "프로필 페이지 지도 조회",
+            description = """
+                지도 영역(bounding box) 내의 프로젝트,스터디를 조회합니다.
+                - swLat ≤ neLat, swLng ≤ neLng 이어야 합니다.
+                """
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "성공",
+                    content = @Content(schema = @Schema(implementation = ApiResponseDto.class),
+                            examples = @ExampleObject(name = "성공 예시", value = """
+                    {
+                      "status": 200,
+                      "message": "프로필 지도 조회에 성공하였습니다.",
+                      "data": [
+                        {
+                          "category": "project",
+                          "projectId": 1,
+                          "title": "구지라지 프로젝트",
+                          "teamStatus": "ONGOING",
+                          "location": {
+                            "address": "부산 해운대구 우동 센텀중앙로 90",
+                            "region1depthName": "부산",
+                            "region2depthName": "해운대구",
+                            "region3depthName": "우동",
+                            "roadName": "센텀중앙로",
+                            "mainBuildingNo": "90",
+                            "subBuildingNo": "",
+                            "zoneNo": "48058",
+                            "latitude": 35.1702,
+                            "longitude": 129.1270
+                          }
+                        },
+                        {
+                          "category": "study",
+                          "studyId": 1,
+                          "title": "구지라지 스터디",
+                          "teamStatus": "CLOSED",
+                          "location": {
+                            "address": "부산 해운대구 우동 센텀중앙로 90",
+                            "region1depthName": "부산",
+                            "region2depthName": "해운대구",
+                            "region3depthName": "우동",
+                            "roadName": "센텀중앙로",
+                            "mainBuildingNo": "90",
+                            "subBuildingNo": "",
+                            "zoneNo": "48058",
+                            "latitude": 35.1702,
+                            "longitude": 129.1270
+                          }
+                        }
+                      ]
+                    }
+                    """))),
+            @ApiResponse(responseCode = "400", description = "잘못된 경계값",
+                    content = @Content(schema = @Schema(implementation = ApiResponseDto.class),
+                            examples = @ExampleObject(name = "경계 오류 예시", value = """
+                    { "status": 400, "message": "잘못된 지도 경계값입니다.", "data": null }
+                    """))),
+            @ApiResponse(responseCode = "400", description = "필수 파라미터 누락",
+                    content = @Content(schema = @Schema(implementation = ApiResponseDto.class),
+                            examples = @ExampleObject(name = "경계 오류 예시", value = """
+                    { "status": 400, "message": "필수 파라미터가 누락되었습니다.", "data": null }
+                    """))),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류",
+                    content = @Content(schema = @Schema(implementation = ApiResponseDto.class),
+                            examples = @ExampleObject(value = """
+                    { "status": 500, "message": "서버 내부 오류", "data": null }
+                    """)))
+    })    @GetMapping("/{userId}/profile/map")
     public ResponseEntity<ApiResponseDto<List<PlayerProfileMapItemResponse>>> getProfileMap(
             @PathVariable Long userId,
 

--- a/src/main/java/goorm/ddok/member/controller/PlayerProfileMapController.java
+++ b/src/main/java/goorm/ddok/member/controller/PlayerProfileMapController.java
@@ -1,0 +1,52 @@
+package goorm.ddok.member.controller;
+
+import goorm.ddok.global.response.ApiResponseDto;
+import goorm.ddok.member.dto.response.PlayerProfileMapItemResponse;
+import goorm.ddok.member.service.PlayerProfileMapService;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/players")
+@RequiredArgsConstructor
+@Tag(name = "Profile", description = "프로필 API")
+public class PlayerProfileMapController {
+
+    private final PlayerProfileMapService playerProfileMapService;
+
+    @GetMapping("/{userId}/profile/map")
+    public ResponseEntity<ApiResponseDto<List<PlayerProfileMapItemResponse>>> getProfileMap(
+            @PathVariable Long userId,
+
+            @Parameter(description = "남서쪽 위도", example = "37.55")
+            @RequestParam @DecimalMin(value = "-90")  @DecimalMax(value = "90") BigDecimal swLat,
+
+            @Parameter(description = "남서쪽 경도", example = "126.97")
+            @RequestParam @DecimalMin(value = "-180") @DecimalMax(value = "180") BigDecimal swLng,
+
+            @Parameter(description = "북동쪽 위도", example = "37.58")
+            @RequestParam @DecimalMin(value = "-90")  @DecimalMax(value = "90")  BigDecimal neLat,
+
+            @Parameter(description = "북동쪽 경도", example = "127.02")
+            @RequestParam @DecimalMin(value = "-180") @DecimalMax(value = "180") BigDecimal neLng,
+
+            @Parameter(description = "중심 위도(선택)", example = "37.5665")
+            @RequestParam(required = false) BigDecimal lat,
+
+            @Parameter(description = "중심 경도(선택)", example = "126.978")
+            @RequestParam(required = false) BigDecimal lng
+    ) {
+        List<PlayerProfileMapItemResponse> data =
+                playerProfileMapService.getProfileMapInBounds(swLat, swLng, neLat, neLng, lat, lng, userId);
+
+        return ResponseEntity.ok(ApiResponseDto.of(200, "프로필 지도 조회에 성공하였습니다.", data));
+    }
+}

--- a/src/main/java/goorm/ddok/member/dto/response/PlayerProfileMapItemResponse.java
+++ b/src/main/java/goorm/ddok/member/dto/response/PlayerProfileMapItemResponse.java
@@ -1,0 +1,70 @@
+package goorm.ddok.member.dto.response;
+
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import goorm.ddok.global.dto.LocationDto;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Schema(
+        name = "PlayerProfileMapItemResponse",
+        description = """
+        플레이어 프로필 아이템 스키마.
+        - category=project: projectId, title, teamStatus, location 포함
+        - category=study:   studyId,   title, teamStatus, location 포함
+        """,
+        example = """
+        {
+          "category": "project",
+          "projectId": 1,
+          "title": "구지라지 프로젝트",
+          "teamStatus": "RECRUITING",
+          "location": {
+            "address": "부산 해운대구 우동 센텀중앙로 90",
+            "region1depthName": "부산",
+            "region2depthName": "해운대구",
+            "region3depthName": "우동",
+            "roadName": "센텀중앙로",
+            "mainBuildingNo": "90",
+            "subBuildingNo": "",
+            "zoneNo": "48058",
+            "latitude": 35.1702,
+            "longitude": 129.1270
+          }
+        }
+        """
+)
+public class PlayerProfileMapItemResponse {
+
+    @Schema(
+            description = "카테고리",
+            example = "project",
+            allowableValues = {"project", "study"},
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
+    private final String category;
+
+    @Schema(description = "프로젝트 ID (category='project'일 때만 존재)", example = "1", nullable = true)
+    private final Long projectId;
+
+    @Schema(description = "스터디 ID (category='study'일 때만 존재)", example = "1", nullable = true)
+    private final Long studyId;
+
+    @Schema(description = "제목 (project|study 공통)", example = "구지라지 프로젝트", nullable = true)
+    private final String title;
+
+    @Schema(
+            description = "팀 상태 (project|study 공통)",
+            example = "RECRUITING",
+            allowableValues = {"RECRUITING", "ONGOING"},
+            nullable = true
+    )
+    private final String teamStatus;
+
+    @Schema(description = "위치 정보", implementation = LocationDto.class, nullable = true)
+    private final LocationDto location;
+}

--- a/src/main/java/goorm/ddok/member/service/PlayerProfileMapService.java
+++ b/src/main/java/goorm/ddok/member/service/PlayerProfileMapService.java
@@ -1,0 +1,158 @@
+package goorm.ddok.member.service;
+
+import goorm.ddok.global.dto.LocationDto;
+import goorm.ddok.global.exception.ErrorCode;
+import goorm.ddok.global.exception.GlobalException;
+import goorm.ddok.member.dto.response.PlayerProfileMapItemResponse;
+import goorm.ddok.member.repository.UserRepository;
+import goorm.ddok.project.repository.ProjectRecruitmentRepository;
+import goorm.ddok.study.repository.StudyRecruitmentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+import java.util.*;
+
+@Service
+@RequiredArgsConstructor
+public class PlayerProfileMapService {
+
+    private final ProjectRecruitmentRepository projectRecruitmentRepository;
+    private final StudyRecruitmentRepository studyRecruitmentRepository;
+    private final UserRepository userRepository;
+
+    public List<PlayerProfileMapItemResponse> getProfileMapInBounds(
+            BigDecimal swLat, BigDecimal swLng,
+            BigDecimal neLat, BigDecimal neLng,
+            BigDecimal centerLat, BigDecimal centerLng,
+            Long userId
+    ){
+
+        if (!userRepository.existsById(userId)) {
+            throw new GlobalException(ErrorCode.USER_NOT_FOUND);
+        }
+
+        validateBounds(swLat, swLng, neLat, neLng);
+
+        List<PlayerProfileMapItemResponse> result = new ArrayList<>();
+
+        var projectRows = projectRecruitmentRepository.findAllInBoundsForProfile(userId, swLat, neLat, swLng, neLng);
+        if (projectRows != null) {
+            List<PlayerProfileMapItemResponse> finalResult = result;
+            projectRows.forEach(r -> finalResult.add(PlayerProfileMapItemResponse.builder()
+                    .category("project")
+                    .projectId(r.getId())
+                    .title(r.getTitle())
+                    .teamStatus(r.getTeamStatus().toString())
+                    .location(LocationDto.builder()
+                            .address(composeRoadAddress(
+                                    r.getRegion1depthName(),
+                                    r.getRegion2depthName(),
+                                    r.getRegion3depthName(),
+                                    r.getRoadName(),
+                                    r.getMainBuildingNo(),
+                                    r.getSubBuildingNo()))
+                            .region1depthName(r.getRegion1depthName())
+                            .region2depthName(r.getRegion2depthName())
+                            .region3depthName(r.getRegion3depthName())
+                            .roadName(r.getRoadName())
+                            .mainBuildingNo(r.getMainBuildingNo())
+                            .subBuildingNo(r.getSubBuildingNo())
+                            .zoneNo(r.getZoneNo())
+                            .latitude(r.getLatitude())
+                            .longitude(r.getLongitude())
+                            .build())
+                    .build()));
+        }
+
+        var studyRows = studyRecruitmentRepository.findAllInBoundsForProfile(userId, swLat, neLat, swLng, neLng);
+        if (studyRows != null) {
+            List<PlayerProfileMapItemResponse> finalResult1 = result;
+            studyRows.forEach(r -> finalResult1.add(PlayerProfileMapItemResponse.builder()
+                    .category("study")
+                    .studyId(r.getId())
+                    .title(r.getTitle())
+                    .teamStatus(r.getTeamStatus().toString())
+                    .location(LocationDto.builder()
+                            .address(composeRoadAddress(
+                                    r.getRegion1depthName(),
+                                    r.getRegion2depthName(),
+                                    r.getRegion3depthName(),
+                                    r.getRoadName(),
+                                    r.getMainBuildingNo(),
+                                    r.getSubBuildingNo()))
+                            .region1depthName(r.getRegion1depthName())
+                            .region2depthName(r.getRegion2depthName())
+                            .region3depthName(r.getRegion3depthName())
+                            .roadName(r.getRoadName())
+                            .mainBuildingNo(r.getMainBuildingNo())
+                            .subBuildingNo(r.getSubBuildingNo())
+                            .zoneNo(r.getZoneNo())
+                            .latitude(r.getLatitude())
+                            .longitude(r.getLongitude())
+                            .build())
+                    .build()));
+        }
+
+        if (centerLat != null && centerLng != null && !result.isEmpty()) {
+            final double cLat = centerLat.doubleValue();
+            final double cLng = centerLng.doubleValue();
+            result = result.stream()
+                    .sorted(Comparator.comparingDouble(item -> {
+                        var loc = item.getLocation();
+                        return haversineKm(
+                                cLat, cLng,
+                                loc.getLatitude().doubleValue(),
+                                loc.getLongitude().doubleValue()
+                        );
+                    }))
+                    .toList();
+        }
+
+        if (result.isEmpty()) {
+            return java.util.Collections.emptyList();
+        }
+
+        return result;
+    }
+
+    public static double haversineKm(double lat1, double lon1, double lat2, double lon2) {
+        final double R = 6371.0;
+        double dLat = Math.toRadians(lat2 - lat1);
+        double dLon = Math.toRadians(lon2 - lon1);
+        double a = Math.sin(dLat / 2) * Math.sin(dLat / 2)
+                + Math.cos(Math.toRadians(lat1)) * Math.cos(Math.toRadians(lat2))
+                * Math.sin(dLon / 2) * Math.sin(dLon / 2);
+        double c = 2.0 * Math.atan2(Math.sqrt(a), Math.sqrt(1.0 - a));
+        return R * c;
+    }
+
+    public String composeRoadAddress(String r1, String r2, String r3,
+                                     String road, String mainNo, String subNo) {
+        if (road == null && r1 == null && r2 == null) return "-";
+        var sb = new StringBuilder();
+        if (r1 != null && !r1.isBlank()) sb.append(r1).append(" ");
+        if (r2 != null && !r2.isBlank()) sb.append(r2).append(" ");
+        if (r3 != null && !r3.isBlank()) sb.append(r3).append(" ");
+        if (road != null && !road.isBlank()) sb.append(road).append(" ");
+
+        String main = mainNo == null ? "" : mainNo.trim();
+        String sub  = subNo == null ? "" : subNo.trim();
+        if (!main.isEmpty() && !sub.isEmpty()) sb.append(main).append("-").append(sub);
+        else if (!main.isEmpty()) sb.append(main);
+
+        return sb.toString().trim();
+    }
+
+    public void validateBounds(BigDecimal swLat, BigDecimal swLng, BigDecimal neLat, BigDecimal neLng) {
+        boolean hasAny = swLat != null || swLng != null || neLat != null || neLng != null;
+        boolean hasAll = swLat != null && swLng != null && neLat != null && neLng != null;
+        if (hasAny && !hasAll) {
+            throw new GlobalException(ErrorCode.REQUIRED_PARAMETER_MISSING);
+        }
+        if (hasAll && (swLat.compareTo(neLat) > 0 || swLng.compareTo(neLng) > 0)) {
+            throw new GlobalException(ErrorCode.INVALID_MAP_BOUNDS);
+        }
+    }
+
+}

--- a/src/main/java/goorm/ddok/project/repository/ProjectRecruitmentRepository.java
+++ b/src/main/java/goorm/ddok/project/repository/ProjectRecruitmentRepository.java
@@ -58,5 +58,41 @@ public interface ProjectRecruitmentRepository extends JpaRepository<ProjectRecru
             @Param("swLng") BigDecimal swLng,
             @Param("neLng") BigDecimal neLng
     );
+
+    @Query("""
+    select distinct
+      pr.id                as id,
+      pr.title             as title,
+      pr.teamStatus        as teamStatus,
+      pr.bannerImageUrl    as bannerImageUrl,
+      pr.region1depthName  as region1depthName,
+      pr.region2depthName  as region2depthName,
+      pr.region3depthName  as region3depthName,
+      pr.roadName          as roadName,
+      pr.mainBuildingNo    as mainBuildingNo,
+      pr.subBuildingNo     as subBuildingNo,
+      pr.zoneNo            as zoneNo,
+      pr.latitude          as latitude,
+      pr.longitude         as longitude
+    from ProjectParticipant pp
+      join pp.position pos
+      join pos.projectRecruitment pr
+    where pp.deletedAt is null
+      and pr.deletedAt is null
+      and pp.user.id = :userId
+      and pr.teamStatus in (goorm.ddok.project.domain.TeamStatus.ONGOING,
+                            goorm.ddok.project.domain.TeamStatus.CLOSED)
+      and pr.latitude  is not null
+      and pr.longitude is not null
+      and pr.latitude  between :swLat and :neLat
+      and pr.longitude between :swLng and :neLng
+""")
+    List<MapRow> findAllInBoundsForProfile(
+            @Param("userId") Long userId,
+            @Param("swLat") BigDecimal swLat,
+            @Param("neLat") BigDecimal neLat,
+            @Param("swLng") BigDecimal swLng,
+            @Param("neLng") BigDecimal neLng
+    );
 }
 

--- a/src/main/java/goorm/ddok/study/repository/StudyRecruitmentRepository.java
+++ b/src/main/java/goorm/ddok/study/repository/StudyRecruitmentRepository.java
@@ -100,4 +100,38 @@ public interface StudyRecruitmentRepository extends JpaRepository<StudyRecruitme
             @Param("swLng") BigDecimal swLng,
             @Param("neLng") BigDecimal neLng
     );
+
+    interface StudyOverlayRow {
+        Long getId();
+        String getTitle();
+        goorm.ddok.study.domain.TeamStatus getTeamStatus();
+        String getBannerImageUrl();
+        goorm.ddok.study.domain.StudyType getStudyType();
+        Integer getCapacity();
+        goorm.ddok.study.domain.StudyMode getMode();
+        String getAddress();
+        Integer getAgeMin();
+        Integer getAgeMax();
+        Integer getExpectedMonth();
+        java.time.LocalDate getStartDate();
+    }
+
+    @Query(value = """
+        SELECT
+            s.id,
+            s.title,
+            s.team_status                          AS teamStatus,
+            s.banner_image_url                     AS bannerImageUrl,
+            s.study_type                           AS studyType,
+            s.mode                                  AS mode,
+            TRIM(BOTH ' ' FROM COALESCE(s.region1depth_name, '') || ' ' || COALESCE(s.region2depth_name, '')) AS address,
+            s.age_min                              AS ageMin,
+            s.age_max                              AS ageMax,
+            s.expected_months                AS expectedMonth,
+            s.start_date                           AS startDate
+        FROM study_recruitment s
+        WHERE s.deleted_at IS NULL
+          AND s.id = :id
+        """, nativeQuery = true)
+    Optional<StudyOverlayRow> findOverlayById(@Param("id") Long id);
 }

--- a/src/main/java/goorm/ddok/study/repository/StudyRecruitmentRepository.java
+++ b/src/main/java/goorm/ddok/study/repository/StudyRecruitmentRepository.java
@@ -65,4 +65,39 @@ public interface StudyRecruitmentRepository extends JpaRepository<StudyRecruitme
             @Param("swLng") BigDecimal swLng,
             @Param("neLng") BigDecimal neLng
     );
+
+    @Query("""
+    select distinct
+      sr.id               as id,
+      sr.title            as title,
+      sr.teamStatus       as teamStatus,
+      sr.bannerImageUrl   as bannerImageUrl,
+      sr.region1depthName as region1depthName,
+      sr.region2depthName as region2depthName,
+      sr.region3depthName as region3depthName,
+      sr.roadName         as roadName,
+      sr.mainBuildingNo   as mainBuildingNo,
+      sr.subBuildingNo    as subBuildingNo,
+      sr.zoneNo           as zoneNo,
+      sr.latitude         as latitude,
+      sr.longitude        as longitude
+    from StudyParticipant sp
+      join sp.studyRecruitment sr
+    where sp.deletedAt is null
+      and sr.deletedAt is null
+      and sp.user.id = :userId
+      and sr.teamStatus in (goorm.ddok.study.domain.TeamStatus.ONGOING,
+                            goorm.ddok.study.domain.TeamStatus.CLOSED)
+      and sr.latitude  is not null
+      and sr.longitude is not null
+      and sr.latitude  between :swLat and :neLat
+      and sr.longitude between :swLng and :neLng
+""")
+    List<MapRow> findAllInBoundsForProfile(
+            @Param("userId") Long userId,
+            @Param("swLat") BigDecimal swLat,
+            @Param("neLat") BigDecimal neLat,
+            @Param("swLng") BigDecimal swLng,
+            @Param("neLng") BigDecimal neLng
+    );
 }


### PR DESCRIPTION
## 🔀 PR 제목

- [Feature] 핀 오버레이 및 프로필 지도 api

---

## 📌 작업 내용 요약
- 핀 오버레이 API 추가: GET /api/map/overlay/{category}/{id}
  - 지원 카테고리: project | study | cafe | player
  - 공통 주소 표기 규칙 적용: "{region1} {region2}" → 예) 서울 강남구
  - Project: 포지션 목록, 정원, 모드, 선호 연령, 예상 개월 수, 시작일 반환
     - project_recruitment 기반, 포지션은 project_recruitment_position에서 CSV → List 변환
  - Study: 스터디 타입, 정원, 모드, 선호 연령, 예상 개월 수, 시작일 반환
  - Cafe: 배너, 평점, 리뷰 수, 주소 반환
  - Player: 닉네임/프로필 이미지/메인포지션/최근 프로젝트·스터디/온도/배지/isMine 반환
    - isMine은 Boolean 래퍼로 변경하여 player가 아닐 때 노출 방지
      - 메인 포지션은 user_position에서 **PRIMARY 우선 → SECONDARY(ord=1)**로 계산
      - “최근 참여”는
        - 프로젝트: project_participant(pp) → project_recruitment_position(prp) → project_recruitment(pr)
        - 스터디: study_participant(sp) → study_recruitment(sr)

- DTO 구성
  - PinOverlayResponse 신설
     - 내부 타입: MainBadge, AbandonBadge, MiniItem
     - @JsonInclude(Include.NON_NULL) 기본 + 필요 시 NON_EMPTY 활용 가능
     - isMine → Boolean (primitive 제거)

- 리포지토리 쿼리
   - ProjectRepository.findOverlayById(...) 네이티브 쿼리
   - StudyRepository.findOverlayById(...) 네이티브 쿼리 
   - CafeRepository.findOverlayById(...) 네이티브 쿼리 
   - UserRepository.findOverlayById(...) 네이티브 쿼리 

- 팀 상태 정규화 로직
  - CLOSED → ONGOING 매핑, null일 때 ONGOING 기본값
  - study.domain.TeamStatus → 문자열 변환 후 통일


---

## ✅ 체크리스트
PR을 올리기 전에 아래 항목을 확인했나요?

- [ ] 기능 요구사항을 모두 구현했나요?
- [ ] 로컬에서 기능을 직접 테스트했나요?
- [ ] 코드 컨벤션 및 스타일을 지켰나요?
- [ ] 관련된 이슈에 연결했나요?

---

## 🔗 관련 이슈
`Closes #이슈번호` 또는 `Related to #이슈번호` 형태로 작성

- Closes #109 

---

## 📎 기타 참고 사항

<img width="970" height="941" alt="스크린샷 2025-09-05 오전 11 01 37" src="https://github.com/user-attachments/assets/17a5cbaf-f786-43c7-aadd-6834c5db6678" />

<img width="954" height="844" alt="스크린샷 2025-09-05 오전 10 56 23" src="https://github.com/user-attachments/assets/2da8766c-4045-4c84-939e-1f463a3a2b71" />

<img width="947" height="749" alt="스크린샷 2025-09-05 오전 10 55 55" src="https://github.com/user-attachments/assets/504f00ae-8697-4681-8e34-3acd01068525" />

<img width="957" height="531" alt="스크린샷 2025-09-05 오전 10 56 52" src="https://github.com/user-attachments/assets/654555b0-e6bd-4266-87fc-a180cb3b613e" />

<img width="963" height="886" alt="스크린샷 2025-09-05 오전 10 57 07" src="https://github.com/user-attachments/assets/2661a76d-10d0-4e6d-bdbb-18d360f3f9ae" />

