### PR TITLE
[Feature] 플레이어 리스트 검색 기능

### DIFF
--- a/src/main/java/goorm/ddok/member/repository/UserRepository.java
+++ b/src/main/java/goorm/ddok/member/repository/UserRepository.java
@@ -3,6 +3,7 @@ package goorm.ddok.member.repository;
 import goorm.ddok.member.domain.UserLocation;
 import org.springframework.data.jpa.repository.JpaRepository;
 import goorm.ddok.member.domain.User;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -10,7 +11,7 @@ import java.math.BigDecimal;
 import java.util.List;
 import java.util.Optional;
 
-public interface UserRepository extends JpaRepository<User, Long> {
+public interface UserRepository extends JpaRepository<User, Long>, JpaSpecificationExecutor<User> {
 
     // 이름 + 휴대폰번호 회원 조회
     Optional<User> findByUsernameAndPhoneNumber(String username, String phoneNumber);

--- a/src/main/java/goorm/ddok/player/controller/ProfileSearchController.java
+++ b/src/main/java/goorm/ddok/player/controller/ProfileSearchController.java
@@ -1,0 +1,105 @@
+package goorm.ddok.player.controller;
+
+import goorm.ddok.global.dto.PageResponse;
+import goorm.ddok.global.response.ApiResponseDto;
+import goorm.ddok.global.security.auth.CustomUserDetails;
+import goorm.ddok.player.dto.response.ProfileSearchResponse;
+import goorm.ddok.player.service.ProfileSearchService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/players")
+@RequiredArgsConstructor
+@Tag(name = "Player", description = "플레이어 검색 API")
+public class ProfileSearchController {
+
+    private final ProfileSearchService profileSearchService;
+
+    @Operation(
+            summary = "플레이어 검색",
+            description = """
+                닉네임, 포지션, 주소를 기준으로 플레이어를 검색합니다.
+                - 검색어는 콤마(,) 또는 공백( )으로 구분하여 여러 개 입력할 수 있습니다.
+                - 검색어가 없으면 전체 공개 프로필을 페이지네이션으로 조회합니다.
+                - 기본 정렬: 닉네임 오름차순(대소문자 구분 없음)
+                - page는 0부터 시작
+                """
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "플레이어 검색 성공",
+            content = @Content(schema = @Schema(implementation = ApiResponseDto.class),
+            examples = @ExampleObject(value = """
+                        {
+                            "status": 200,
+                            "message": "플레이어 검색이 성공적으로 처리되었습니다.",
+                            "data": {
+                                "pagination": {
+                                    "currentPage": 0,
+                                    "pageSize": 10,
+                                    "totalPages": 1,
+                                    "totalItems": 1
+                                },
+                                "items": [
+                                    {
+                                        "userId": 1,
+                                        "category": "players",
+                                        "nickname": "요망한 백엔드",
+                                        "profileImageUrl": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI0OCIgaGVpZ2h0PSI0OCI+CiAgPHJlY3Qgd2lkdGg9IjEwMCUiIGhlaWdodD0iMTAwJSIgZmlsbD0iI0Y1Q0JBNyIvPgogIDx0ZXh0IHg9IjUwJSIgeT0iNTUlIiBmb250LXNpemU9IjE1IiBmaWxsPSJibGFjayIgZm9udC13ZWlnaHQ9ImJvbGQiIHRleHQtYW5jaG9yPSJtaWRkbGUiIGRvbWluYW50LWJhc2VsaW5lPSJtaWRkbGUiIGZvbnQtZmFtaWx5PSJJbnRlciI+7JqU67CxPC90ZXh0Pgo8L3N2Zz4K",
+                                        "mainBadge": {
+                                            "type": "login",
+                                            "tier": "bronze"
+                                        },
+                                        "abandonBadge": {
+                                            "count": 5,
+                                            "granted": true
+                                        },
+                                        "mainPosition": "백엔드",
+                                        "address": "전북 익산시",
+                                        "temperature": 36.5,
+                                        "chatRoomId": null,
+                                        "dmRequestPending": false,
+                                        "isMine": false
+                                    }
+                                ]
+                            }
+                        }
+                       """)))
+    })
+    @GetMapping("/search")
+    public ResponseEntity<ApiResponseDto<PageResponse<ProfileSearchResponse>>> search(
+            @Parameter(description = "검색어(닉네임/포지션/주소). 콤마/공백 구분", example = "똑똑이,강남구,백엔드")
+            @RequestParam(required = false) String keyword,
+
+            @Parameter(description = "페이지(0-base)", example = "0")
+            @RequestParam(defaultValue = "0") int page,
+
+            @Parameter(description = "페이지 크기", example = "10")
+            @RequestParam(defaultValue = "10") int size,
+
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        Long currentUserId = (userDetails != null) ? userDetails.getId() : null;
+
+        Page<ProfileSearchResponse> result =
+                profileSearchService.searchPlayers(keyword, page, size, currentUserId);
+
+        return ResponseEntity.ok(
+                ApiResponseDto.of(200, "플레이어 검색이 성공적으로 처리되었습니다.", PageResponse.of(result))
+        );
+    }
+}

--- a/src/main/java/goorm/ddok/player/dto/response/ProfileSearchResponse.java
+++ b/src/main/java/goorm/ddok/player/dto/response/ProfileSearchResponse.java
@@ -1,0 +1,51 @@
+package goorm.ddok.player.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ProfileSearchResponse {
+
+    private final Long userId;
+    private final String category;
+    private final String nickname;
+    private final String profileImageUrl;
+
+    private final MainBadge mainBadge;
+    private final AbandonBadge abandonBadge;
+
+    private final String mainPosition;
+    private final String address;
+    private final Double temperature;
+
+    private final boolean IsMine;
+
+    private final Long chatRoomId;
+    private final boolean dmRequestPending;
+
+    @Getter
+    @Builder
+    @Schema(description = "메인 뱃지 정보")
+    public static class MainBadge {
+        @Schema(description = "뱃지 타입", example = "login")
+        private final String type;
+
+        @Schema(description = "뱃지 등급", example = "bronze")
+        private final String tier;
+    }
+
+    @Getter
+    @Builder
+    @Schema(description = "탈주 뱃지 정보")
+    public static class AbandonBadge {
+        @Schema(description = "뱃지 부여 여부", example = "false")
+        private final boolean isGranted;
+
+        @Schema(description = "포기 횟수", example = "0")
+        private final Integer count;
+    }
+}

--- a/src/main/java/goorm/ddok/player/dto/response/ProfileSearchResponse.java
+++ b/src/main/java/goorm/ddok/player/dto/response/ProfileSearchResponse.java
@@ -41,7 +41,7 @@ public class ProfileSearchResponse {
     @Schema(description = "내 프로필 여부", example = "true")
     private final boolean IsMine;
 
-    @Schema(description = "채팅방 ID", example = "1")
+    @Schema(description = "채팅방 ID", example = "1", nullable = true)
     private final Long chatRoomId;
 
     @Schema(description = "1:1 대화 요청 상태", example = "false")

--- a/src/main/java/goorm/ddok/player/dto/response/ProfileSearchResponse.java
+++ b/src/main/java/goorm/ddok/player/dto/response/ProfileSearchResponse.java
@@ -1,13 +1,11 @@
 package goorm.ddok.player.dto.response;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
 @Builder
-@JsonInclude(JsonInclude.Include.NON_NULL)
 @Schema(name = "ProfileSearchResponse", description = "플레이어 검색 응답")
 public class ProfileSearchResponse {
 

--- a/src/main/java/goorm/ddok/player/dto/response/ProfileSearchResponse.java
+++ b/src/main/java/goorm/ddok/player/dto/response/ProfileSearchResponse.java
@@ -8,23 +8,43 @@ import lombok.Getter;
 @Getter
 @Builder
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@Schema(name = "ProfileSearchResponse", description = "플레이어 검색 응답")
 public class ProfileSearchResponse {
 
+    @Schema(description = "플레이어 사용자 ID", example = "1")
     private final Long userId;
+
+    @Schema(description = "카테고리", example = "player")
     private final String category;
+
+    @Schema(description = "플레이어 닉네임 (category='player')", example = "멍한 백엔드")
     private final String nickname;
+
+    @Schema(description = "프로필 이미지 URL", example = "https://cdn.example.com/profile.png")
     private final String profileImageUrl;
 
+    @Schema(description = "메인 뱃지")
     private final MainBadge mainBadge;
+
+    @Schema(description = "탈주 뱃지")
     private final AbandonBadge abandonBadge;
 
+    @Schema(description = "메인 포지션)", example = "백엔드")
     private final String mainPosition;
+
+    @Schema(description = "주소", example = "서울 강남구")
     private final String address;
+
+    @Schema(description = "온도", example = "36.6")
     private final Double temperature;
 
+    @Schema(description = "내 프로필 여부", example = "true")
     private final boolean IsMine;
 
+    @Schema(description = "채팅방 ID", example = "1")
     private final Long chatRoomId;
+
+    @Schema(description = "1:1 대화 요청 상태", example = "false")
     private final boolean dmRequestPending;
 
     @Getter

--- a/src/main/java/goorm/ddok/player/service/ProfileSearchService.java
+++ b/src/main/java/goorm/ddok/player/service/ProfileSearchService.java
@@ -1,0 +1,216 @@
+package goorm.ddok.player.service;
+
+import goorm.ddok.member.domain.User;
+import goorm.ddok.member.domain.UserLocation;
+import goorm.ddok.member.domain.UserPosition;
+import goorm.ddok.member.domain.UserPositionType;
+import goorm.ddok.member.repository.UserRepository;
+import goorm.ddok.player.dto.response.ProfileSearchResponse;
+import jakarta.persistence.criteria.Join;
+import jakarta.persistence.criteria.JoinType;
+import jakarta.persistence.criteria.Predicate;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.util.StringUtils.hasText;
+
+
+import java.util.*;
+
+@Service
+@RequiredArgsConstructor
+public class ProfileSearchService {
+
+    private final UserRepository userRepository;
+
+    @Transactional(readOnly = true)
+    public Page<ProfileSearchResponse> searchPlayers(String keyword, int page, int size, Long currentUserId) {
+
+        Pageable pageable = PageRequest.of(
+                page,
+                size,
+                Sort.by(Sort.Order.asc("nickname").ignoreCase())
+        );
+        Specification<User> spec = Specification.where(null);
+
+        if (hasText(keyword)) {
+            spec = spec.and(keywordSpec(keyword));
+        }
+
+        Page<User> rows = userRepository.findAll(spec, pageable);
+
+        return rows.map(u -> toResponse(u, currentUserId));
+    }
+
+    private Specification<User> keywordSpec(String raw) {
+        List<String> tokens = splitTokens(raw);
+
+        return (root, q, cb) -> {
+            if (Objects.requireNonNull(q).getResultType() != Long.class && q.getResultType() != long.class) {
+                q.distinct(true);
+            }
+
+            Join<User, UserPosition> posJoin = root.join("positions", JoinType.LEFT);
+            Join<User, UserLocation> locJoin = root.join("location", JoinType.LEFT);
+
+            List<Predicate> andPerToken = new ArrayList<>();
+            for (String token : tokens) {
+                String like = "%" + token.toLowerCase() + "%";
+
+                List<Predicate> orPredicates = new ArrayList<>();
+
+                orPredicates.add(cb.like(cb.lower(root.get("nickname")), like));
+
+                Predicate isPublicCondition = cb.isTrue(root.get("isPublic"));
+
+                orPredicates.add(
+                        cb.and(
+                                isPublicCondition,
+                                cb.like(cb.lower(posJoin.get("positionName")), like)
+                        )
+                );
+
+                orPredicates.add(
+                        cb.and(
+                                isPublicCondition,
+                                cb.like(cb.lower(cb.coalesce(locJoin.get("region1DepthName"), "")), like)
+                        )
+                );
+
+                orPredicates.add(
+                        cb.and(
+                                isPublicCondition,
+                                cb.like(cb.lower(cb.coalesce(locJoin.get("region2DepthName"), "")), like)
+                        )
+                );
+
+                orPredicates.add(
+                        cb.and(
+                                isPublicCondition,
+                                cb.like(cb.lower(cb.coalesce(locJoin.get("region3DepthName"), "")), like)
+                        )
+                );
+
+                orPredicates.add(
+                        cb.and(
+                                isPublicCondition,
+                                cb.like(cb.lower(cb.coalesce(locJoin.get("roadName"), "")), like)
+                        )
+                );
+
+                orPredicates.add(
+                        cb.and(
+                                isPublicCondition,
+                                cb.like(cb.lower(cb.coalesce(locJoin.get("mainBuildingNo"), "")), like)
+                        )
+                );
+
+                orPredicates.add(
+                        cb.and(
+                                isPublicCondition,
+                                cb.like(cb.lower(cb.coalesce(locJoin.get("subBuildingNo"), "")), like)
+                        )
+                );
+
+                orPredicates.add(
+                        cb.and(
+                                isPublicCondition,
+                                cb.like(
+                                        cb.lower(
+                                                cb.concat(
+                                                        cb.concat(cb.coalesce(locJoin.get("region1DepthName"), ""), " "),
+                                                        cb.coalesce(locJoin.get("region2DepthName"), "")
+                                                )
+                                        ),
+                                        like
+                                )
+                        )
+                );
+
+                Predicate orForOneToken = cb.or(orPredicates.toArray(new Predicate[0]));
+                andPerToken.add(orForOneToken);
+            }
+            return cb.and(andPerToken.toArray(new Predicate[0]));
+        };
+    }
+
+    private List<String> splitTokens(String raw) {
+        return Arrays.stream(raw.split("[,\\s]+"))
+                .map(String::trim)
+                .filter(t -> !t.isEmpty())
+                .distinct()
+                .toList();
+    }
+
+    private ProfileSearchResponse toResponse(User u, Long currentUserId) {
+
+        boolean isMine = Objects.equals(u.getId(), currentUserId);
+        boolean isPublic = u.isPublic();
+
+        String address = null;
+        String mainPosition = null;
+
+        // isPublic이 true이거나 본인인 경우에만 주소와 포지션 정보 제공
+        if (isPublic || isMine) {
+            address = shortAddress(
+                    u.getLocation() == null ? null : u.getLocation().getRegion1DepthName(),
+                    u.getLocation() == null ? null : u.getLocation().getRegion2DepthName()
+            );
+            mainPosition = pickMainPosition(u);
+        }
+
+        return ProfileSearchResponse.builder()
+                .userId(u.getId())
+                .category("players")
+                .nickname(u.getNickname())
+                .profileImageUrl(u.getProfileImageUrl())
+                .mainBadge(ProfileSearchResponse
+                        .MainBadge
+                        .builder()
+                        .type("login")
+                        .tier("bronze")
+                        .build()) // TODO: 배지 도메인 연동
+                .abandonBadge(ProfileSearchResponse
+                        .AbandonBadge
+                        .builder()
+                        .isGranted(true)
+                        .count(5)
+                        .build()) // TODO: 배지 도메인 연동
+                .mainPosition(mainPosition) // isPublic이 false이면 null
+                .address(address) // isPublic이 false이면 null
+                .temperature(36.5) // TODO: 평판/온도 도메인 연동
+                .IsMine(currentUserId != null && currentUserId.equals(u.getId()))
+                .chatRoomId(null) // TODO: 채팅 도메인 연동
+                .dmRequestPending(false) // TODO: DM 도메인 연동
+                .build();
+    }
+
+    private String pickMainPosition(User u) {
+        if (u.getPositions() == null || u.getPositions().isEmpty()) return null;
+
+        Optional<UserPosition> primary = u.getPositions().stream()
+                .filter(p -> p.getType() == UserPositionType.PRIMARY)
+                .findFirst();
+        if (primary.isPresent()) return primary.get().getPositionName();
+
+        Optional<UserPosition> sec1 = u.getPositions().stream()
+                .filter(p -> p.getType() == UserPositionType.SECONDARY && Short.valueOf((short)1).equals(p.getOrd()))
+                .findFirst();
+        if (sec1.isPresent()) return sec1.get().getPositionName();
+
+        return u.getPositions().get(0).getPositionName();
+    }
+
+    private String shortAddress(String region1, String region2) {
+        String r1 = region1 == null ? "" : region1.trim();
+        String r2 = region2 == null ? "" : region2.trim();
+        if (r1.isEmpty() && r2.isEmpty()) return "-";
+        return (r1 + " " + r2).trim();
+    }
+}


### PR DESCRIPTION
## 🔀 PR 제목

- [Feature] 플레이어 리스트 검색 기능

---

## 📌 작업 내용 요약

- 플레이어 검색 API 구현: GET /api/players/search
- 검색 키워드(닉네임/포지션/주소) 토큰화(공백·콤마 기준) 후 AND 매칭, 각 토큰은 OR 조건으로 닉네임/주소/포지션에 적용
- 개인정보 보호 반영:
  - isPublic=false 사용자는 닉네임으로만 검색 매칭됨 (포지션/주소 검색엔 제외)
  - 응답에서 isPublic=false 사용자의 address, mainPosition은 마스킹(null)
  - isMine=true인 경우 본인 데이터는 전체 노출

- 정렬: 닉네임 오름차순(Criteria 정렬로 처리, Null precedence 미사용)
- 페이지네이션 지원: page, size 파라미터
- N+1 방지: 위치·포지션 LEFT JOIN 기반 스펙 구성 및 query.distinct(true) 처리
- 응답 DTO 구성: userId, category=players, nickname, profileImageUrl, mainBadge, abandonBadge, mainPosition, address, temperature, isMine, chatRoomId, dmRequestPending

---

## ✅ 체크리스트
PR을 올리기 전에 아래 항목을 확인했나요?

- [ ] 기능 요구사항을 모두 구현했나요?
- [ ] 로컬에서 기능을 직접 테스트했나요?
- [ ] 코드 컨벤션 및 스타일을 지켰나요?
- [ ] 관련된 이슈에 연결했나요?

---

## 🔗 관련 이슈

- Closes #134

---

## 📎 기타 참고 사항

<img width="892" height="854" alt="스크린샷 2025-09-07 오전 6 46 23" src="https://github.com/user-attachments/assets/dada7fbe-2cdd-40cf-9ba0-8f9bb14b770e" />
<img width="892" height="851" alt="스크린샷 2025-09-07 오전 6 46 31" src="https://github.com/user-attachments/assets/fbd8ae31-c9b7-4725-86a0-543b32fb0088" />
