### PR TITLE
fix(study): 오버레이 조회 시 capacity 컬럼 누락 수정

### DIFF
--- a/src/main/java/goorm/ddok/study/repository/StudyRecruitmentRepository.java
+++ b/src/main/java/goorm/ddok/study/repository/StudyRecruitmentRepository.java
@@ -126,6 +126,7 @@ public interface StudyRecruitmentRepository extends JpaRepository<StudyRecruitme
             s.team_status                          AS teamStatus,
             s.banner_image_url                     AS bannerImageUrl,
             s.study_type                           AS studyType,
+            s.capacity                              AS capacity,
             s.mode                                  AS mode,
             TRIM(BOTH ' ' FROM COALESCE(s.region1depth_name, '') || ' ' || COALESCE(s.region2depth_name, '')) AS address,
             s.age_min                              AS ageMin,


### PR DESCRIPTION
## 🔀 PR 제목
- [Fix] 스터디 오버레이 조회 시 capacity 누락 수정

---

## 📌 작업 내용 요약
어떤 작업을 했는지 간략히 설명해주세요.

- StudyRecruitmentRepository.findOverlayById 쿼리에 capacity 컬럼 추가
- 지도 오버레이 조회 API(MapService.getOverlay)에서 study 카테고리 조회 시 capacity 값 정상 반환되도록 수정

---

## ✅ 체크리스트
PR을 올리기 전에 아래 항목을 확인했나요?

- [x] 기능 요구사항을 모두 구현했나요?
- [x] 로컬에서 기능을 직접 테스트했나요?
- [x] 코드 컨벤션 및 스타일을 지켰나요?
- [x] 관련된 이슈에 연결했나요?

---

## 🔗 관련 이슈
`Closes #이슈번호` 또는 `Related to #이슈번호` 형태로 작성


- Closes #157 
- Related to #157 
---

## 📎 기타 참고 사항
추가로 리뷰어가 참고해야 할 사항이 있다면 적어주세요.

<img width="922" height="1241" alt="image" src="https://github.com/user-attachments/assets/2f43205f-f76e-4671-9df1-28a3bdfe6f3c" />

