### PR TITLE
feat(프로젝트 수정 시 기본 배너 이미지 생성 로직 추가): 프로젝트 수정 시 기본 배너 이미지 생성 로직 추가 DP-348

### DIFF
--- a/src/main/java/goorm/ddok/project/service/ProjectRecruitmentEditService.java
+++ b/src/main/java/goorm/ddok/project/service/ProjectRecruitmentEditService.java
@@ -215,7 +215,9 @@ public class ProjectRecruitmentEditService {
         }
 
         // 배너: 파일 > 요청 URL > 기존 > 기본
-        String bannerUrl = resolveBannerUrl(bannerImage, req.getBannerImageUrl(), pr.getBannerImageUrl(), req.getTitle());
+        String bannerUrl= (bannerImage != null && !bannerImage.isEmpty())
+                ? uploadBannerImage(bannerImage)
+                : bannerImageService.generateBannerImageUrl(req.getTitle(), "PROJECT", 1200, 600);
 
         // 위치 업데이트 (카카오 필드 개별 저장)
         boolean offline = req.getMode() == ProjectMode.offline;
@@ -278,6 +280,14 @@ public class ProjectRecruitmentEditService {
             }
         }
         pr.getTraits().removeIf(t -> !desired.contains(t.getTraitName()));
+    }
+
+    private String uploadBannerImage(MultipartFile file) {
+        try {
+            return fileService.upload(file);
+        } catch (IOException e) {
+            throw new GlobalException(ErrorCode.BANNER_UPLOAD_FAILED);
+        }
     }
 
     private void mergePositionsStrict(ProjectRecruitment pr, List<String> desired) {


### PR DESCRIPTION
## 🔀 PR 제목
- [Fix] 프로젝트 수정 시 기본 배너 이미지 생성 로직 추가

---

## 📌 작업 내용 요약
어떤 작업을 했는지 간략히 설명해주세요.

- 프로젝트 수정 시 기본 배너 이미지 생성 로직 추가

---

## ✅ 체크리스트
PR을 올리기 전에 아래 항목을 확인했나요?

- [ ] 기능 요구사항을 모두 구현했나요?
- [ ] 로컬에서 기능을 직접 테스트했나요?
- [ ] 코드 컨벤션 및 스타일을 지켰나요?
- [ ] 관련된 이슈에 연결했나요?

---

## 🔗 관련 이슈
`Closes #이슈번호` 또는 `Related to #이슈번호` 형태로 작성

예시:
- Closes #160 
- Related to #160
---

## 📎 기타 참고 사항
추가로 리뷰어가 참고해야 할 사항이 있다면 적어주세요.

예시:
- 테스트
<img width="2132" height="1296" alt="스크린샷 2025-09-09 오전 1 10 23" src="https://github.com/user-attachments/assets/0e5ee40b-da6b-455c-bd64-01c16f38a14d" />

<img width="1174" height="583" alt="image" src="https://github.com/user-attachments/assets/c1b3b46d-f23a-4d86-934c-c8f385ef4da3" />


