### PR TITLE
Feature/dp 354 badge system apply

### DIFF
--- a/src/main/java/goorm/ddok/badge/service/BadgeService.java
+++ b/src/main/java/goorm/ddok/badge/service/BadgeService.java
@@ -143,7 +143,7 @@ public class BadgeService {
      * 프로젝트/스터디 종료 배지 부여
      *
      * 프로젝트 또는 스터디가 성공적으로 종료될 때 호출.
-     * - 모든 참여자: complete 배지 증가
+     * - 멤버: complete 배지 증가
      * - 리더: leader_complete 배지 추가 증가
      *
      * @param user    배지를 부여할 사용자
@@ -151,9 +151,10 @@ public class BadgeService {
      */
     @Transactional
     public void grantCompleteBadge(User user, boolean isLeader) {
-        increaseBadge(user, BadgeType.complete);
         if (isLeader) {
             increaseBadge(user, BadgeType.leader_complete);
+        } else {
+            increaseBadge(user, BadgeType.complete);
         }
     }
 

--- a/src/main/java/goorm/ddok/badge/service/BadgeService.java
+++ b/src/main/java/goorm/ddok/badge/service/BadgeService.java
@@ -13,6 +13,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Comparator;
 import java.util.List;
 
 @Service
@@ -23,6 +26,13 @@ public class BadgeService {
 
     /**
      * 배지 카운트 증가
+     *
+     * 특정 유저의 배지(totalCnt)를 +1 증가시킨다.
+     * 해당 배지가 존재하지 않으면 새로 생성한 후 카운트를 1로 설정한다.
+     *
+     * @param user      배지를 증가시킬 사용자
+     * @param badgeType 증가시킬 배지 타입
+     * @return 갱신된 UserBadge 엔티티
      */
     public UserBadge increaseBadge(User user, BadgeType badgeType) {
         UserBadge userBadge = userBadgeRepository.findByUserAndBadgeType(user, badgeType)
@@ -35,6 +45,12 @@ public class BadgeService {
 
     /**
      * 착한 배지 조회
+     *
+     * complete, leader_complete, login 배지들을 조회하고,
+     * 각 배지의 누적 횟수(totalCnt)에 따라 현재 티어(bronze/silver/gold)를 계산하여 반환한다.
+     *
+     * @param user 배지를 조회할 사용자
+     * @return 착한 배지 리스트 (BadgeDto)
      */
     @Transactional(readOnly = true)
     public List<BadgeDto> getGoodBadges(User user) {
@@ -50,6 +66,12 @@ public class BadgeService {
 
     /**
      * 나쁜 배지 조회
+     *
+     * abandon(탈주) 배지 조회.
+     * 누적 횟수가 0보다 크면 획득한 것으로 간주한다.
+     *
+     * @param user 배지를 조회할 사용자
+     * @return 나쁜 배지 정보 (AbandonBadgeDto)
      */
     @Transactional(readOnly = true)
     public AbandonBadgeDto getAbandonBadge(User user) {
@@ -66,6 +88,12 @@ public class BadgeService {
 
     /**
      * 착한 배지 변환
+     *
+     * UserBadge 엔티티를 BadgeDto로 변환하면서,
+     * totalCnt 기준으로 티어를 계산하여 함께 반환한다.
+     *
+     * @param userBadge 변환할 유저 배지 엔티티
+     * @return BadgeDto (배지 타입 + 티어)
      */
     private BadgeDto toGoodBadgeDto(UserBadge userBadge) {
         BadgeTier tier = calculateTier(userBadge.getBadgeType(), userBadge.getTotalCnt());
@@ -77,6 +105,14 @@ public class BadgeService {
 
     /**
      * 누적 카운트에 따른 티어 계산
+     *
+     * BadgeTierRule 테이블에서 totalCnt 이하의 가장 큰 requiredCnt를 찾아
+     * 해당 룰의 티어(bronze/silver/gold)를 반환한다.
+     * 조건에 맞는 룰이 없으면 bronze로 기본 설정된다.
+     *
+     * @param type     배지 타입
+     * @param totalCnt 누적 카운트
+     * @return 계산된 배지 티어
      */
     private BadgeTier calculateTier(BadgeType type, int totalCnt) {
         return badgeTierRuleRepository
@@ -84,6 +120,70 @@ public class BadgeService {
                 .map(BadgeTierRule::getTier)
                 .orElse(BadgeTier.bronze);
     }
+
+    /**
+     * 로그인 배지 부여 (1일 1회 제한)
+     *
+     * @param user 로그인한 사용자
+     */
+    @Transactional
+    public void grantLoginBadge(User user) {
+        // 오늘 이미 로그인 배지 반영했는지 확인
+        boolean alreadyGrantedToday = userBadgeRepository.findByUserAndBadgeType(user, BadgeType.login)
+                .map(badge -> badge.getUpdatedAt() != null &&
+                        badge.getUpdatedAt().isAfter(Instant.now().truncatedTo(ChronoUnit.DAYS)))
+                .orElse(false);
+
+        if (!alreadyGrantedToday) {
+            increaseBadge(user, BadgeType.login);
+        }
+    }
+
+    /**
+     * 프로젝트/스터디 종료 배지 부여
+     *
+     * 프로젝트 또는 스터디가 성공적으로 종료될 때 호출.
+     * - 모든 참여자: complete 배지 증가
+     * - 리더: leader_complete 배지 추가 증가
+     *
+     * @param user    배지를 부여할 사용자
+     * @param isLeader 리더 여부
+     */
+    @Transactional
+    public void grantCompleteBadge(User user, boolean isLeader) {
+        increaseBadge(user, BadgeType.complete);
+        if (isLeader) {
+            increaseBadge(user, BadgeType.leader_complete);
+        }
+    }
+
+    /**
+     * 대표 착한 배지 조회
+     *
+     * complete, leader_complete, login 배지 중
+     * 1순위 totalCnt (내림차순, max)
+     * 2순위 updateAt (가장 최신)
+     *
+     * @param user 대표 배지를 조회할 사용자
+     * @return 대표 배지 (없으면 null)
+     */
+    @Transactional(readOnly = true)
+    public BadgeDto getRepresentativeGoodBadge(User user) {
+        List<UserBadge> badges = userBadgeRepository.findByUserAndBadgeTypeIn(
+                user,
+                List.of(BadgeType.complete, BadgeType.leader_complete, BadgeType.login)
+        );
+
+        return badges.stream()
+                .max(Comparator.comparingInt(UserBadge::getTotalCnt)
+                        .thenComparing(UserBadge::getUpdatedAt, Comparator.nullsLast(Comparator.naturalOrder())))
+                .map(b -> BadgeDto.builder()
+                        .type(b.getBadgeType())
+                        .tier(calculateTier(b.getBadgeType(), b.getTotalCnt()))
+                        .build())
+                .orElse(null);
+    }
+
 
 
 }

--- a/src/main/java/goorm/ddok/map/service/MapService.java
+++ b/src/main/java/goorm/ddok/map/service/MapService.java
@@ -1,12 +1,12 @@
 package goorm.ddok.map.service;
 
+import goorm.ddok.badge.service.BadgeService;
 import goorm.ddok.cafe.repository.CafeRepository;
-import goorm.ddok.global.dto.LocationDto;
-import goorm.ddok.global.dto.PageResponse;
-import goorm.ddok.global.dto.PreferredAgesDto;
+import goorm.ddok.global.dto.*;
 import goorm.ddok.global.exception.ErrorCode;
 import goorm.ddok.global.exception.GlobalException;
 import goorm.ddok.map.dto.response.*;
+import goorm.ddok.member.domain.User;
 import goorm.ddok.member.repository.UserRepository;
 import goorm.ddok.project.repository.ProjectRecruitmentRepository;
 import goorm.ddok.study.repository.StudyRecruitmentRepository;
@@ -29,6 +29,8 @@ public class MapService {
     private final StudyRecruitmentRepository studyRecruitmentRepository;
     private final UserRepository userRepository;
     private final CafeRepository cafeRepository;
+    private final BadgeService badgeService;
+
 
     private static final Double DEFAULT_TEMPERATURE = 36.5;
 
@@ -501,40 +503,57 @@ public class MapService {
             var rows = userRepository.findPublicPlayersInBounds(swLat, neLat, swLng, neLng);
 
             if (rows != null) {
-                rows.forEach(r -> items.add(AllMapItemSearchResponse.builder()
-                        .category("player")
-                        .userId(r.getId())
-                        .nickname(r.getNickname())
-                        .IsMine(userId != null && userId.equals(r.getId()))
-                        .profileImageUrl(r.getProfileImageUrl())
-                        .temperature(DEFAULT_TEMPERATURE)
-                        .mainBadge(AllMapItemSearchResponse.MainBadge.builder()
-                                .type("login")
-                                .tier("bronze")
-                                .build())
-                        .abandonBadge(AllMapItemSearchResponse.AbandonBadge.builder()
-                                .IsGranted(true)
-                                .count(5)
-                                .build())
-                        .location(LocationDto.builder()
-                                .address(composeRoadAddress(
-                                        r.getRegion1DepthName(),
-                                        r.getRegion2DepthName(),
-                                        r.getRegion3DepthName(),
-                                        r.getRoadName(),
-                                        r.getMainBuildingNo(),
-                                        r.getSubBuildingNo()))
-                                .region1depthName(r.getRegion1DepthName())
-                                .region2depthName(r.getRegion2DepthName())
-                                .region3depthName(r.getRegion3DepthName())
-                                .roadName(r.getRoadName())
-                                .mainBuildingNo(r.getMainBuildingNo())
-                                .subBuildingNo(r.getSubBuildingNo())
-                                .zoneNo(r.getZoneNo())
-                                .latitude(r.getLatitude())
-                                .longitude(r.getLongitude())
-                                .build())
-                        .build()));
+                rows.forEach(r -> {
+                    User user = userRepository.findById(r.getId())
+                            .orElseThrow(() -> new GlobalException(ErrorCode.USER_NOT_FOUND));
+
+                    // 대표 배지
+                    BadgeDto representative = badgeService.getRepresentativeGoodBadge(user);
+                    AllMapItemSearchResponse.MainBadge mainBadge = null;
+                    if (representative != null) {
+                        mainBadge = AllMapItemSearchResponse.MainBadge.builder()
+                                .type(representative.getType().name())
+                                .tier(representative.getTier().name())
+                                .build();
+                    }
+
+                    // 나쁜 배지
+                    AbandonBadgeDto abandon = badgeService.getAbandonBadge(user);
+                    AllMapItemSearchResponse.AbandonBadge abandonBadge =
+                            AllMapItemSearchResponse.AbandonBadge.builder()
+                                    .IsGranted(abandon.isIsGranted())
+                                    .count(abandon.getCount())
+                                    .build();
+
+                    items.add(AllMapItemSearchResponse.builder()
+                            .category("player")
+                            .userId(r.getId())
+                            .nickname(r.getNickname())
+                            .IsMine(userId != null && userId.equals(r.getId()))
+                            .profileImageUrl(r.getProfileImageUrl())
+                            .temperature(DEFAULT_TEMPERATURE)
+                            .mainBadge(mainBadge)
+                            .abandonBadge(abandonBadge)
+                            .location(LocationDto.builder()
+                                    .address(composeRoadAddress(
+                                            r.getRegion1DepthName(),
+                                            r.getRegion2DepthName(),
+                                            r.getRegion3DepthName(),
+                                            r.getRoadName(),
+                                            r.getMainBuildingNo(),
+                                            r.getSubBuildingNo()))
+                                    .region1depthName(r.getRegion1DepthName())
+                                    .region2depthName(r.getRegion2DepthName())
+                                    .region3depthName(r.getRegion3DepthName())
+                                    .roadName(r.getRoadName())
+                                    .mainBuildingNo(r.getMainBuildingNo())
+                                    .subBuildingNo(r.getSubBuildingNo())
+                                    .zoneNo(r.getZoneNo())
+                                    .latitude(r.getLatitude())
+                                    .longitude(r.getLongitude())
+                                    .build())
+                            .build());
+                });
             }
         }
 
@@ -739,19 +758,31 @@ public class MapService {
             latestStudyStatus = normalizeStudyTeamStatus(row.getLatestStudyTeamStatus());
         }
 
+        User user = userRepository.findById(row.getId())
+                .orElseThrow(() -> new GlobalException(ErrorCode.USER_NOT_FOUND));
+        BadgeDto representative = badgeService.getRepresentativeGoodBadge(user);
+        PinOverlayResponse.MainBadge mainBadge = null;
+        if (representative != null) {
+            mainBadge = PinOverlayResponse.MainBadge.builder()
+                    .type(representative.getType().name())
+                    .tier(representative.getTier().name())
+                    .build();
+        }
+
+        AbandonBadgeDto abandon = badgeService.getAbandonBadge(user);
+        PinOverlayResponse.AbandonBadge abandonBadge =
+                PinOverlayResponse.AbandonBadge.builder()
+                        .IsGranted(abandon.isIsGranted())
+                        .count(abandon.getCount())
+                        .build();
+
         return PinOverlayResponse.builder()
                 .category("player")
                 .userId(row.getId())
                 .nickname(row.getNickname())
                 .profileImageUrl(profile)
-                .mainBadge(PinOverlayResponse.MainBadge.builder()
-                        .type("login")
-                        .tier("bronze")
-                        .build())
-                .abandonBadge(PinOverlayResponse.AbandonBadge.builder()
-                        .IsGranted(true)
-                        .count(5)
-                        .build())
+                .mainBadge(mainBadge)
+                .abandonBadge(abandonBadge)
                 .mainPosition(row.getMainPosition())
                 .address(row.getAddress())
                 .latestProject(toMini(row.getLatestProjectId(), row.getLatestProjectTitle(), latestProjectStatus))

--- a/src/main/java/goorm/ddok/member/dto/ProfileDto.java
+++ b/src/main/java/goorm/ddok/member/dto/ProfileDto.java
@@ -1,5 +1,7 @@
 package goorm.ddok.member.dto;
 
+import goorm.ddok.global.dto.AbandonBadgeDto;
+import goorm.ddok.global.dto.BadgeDto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 
@@ -24,8 +26,8 @@ public class ProfileDto {
     private String mainPosition;
     private List<String> subPositions;
 
-    private Badge mainBadge;        // 요구: 값 없으면 null
-    private AbandonBadge abandonBadge; // 요구: 값 없으면 null
+    private BadgeDto mainBadge;        // 요구: 값 없으면 null
+    private AbandonBadgeDto abandonBadge; // 요구: 값 없으면 null
 
     private ActiveHours activeHours;
     private List<String> traits;
@@ -38,18 +40,6 @@ public class ProfileDto {
     private LocationBlock location;
 
     private List<String> techStacks;
-
-    @Getter @AllArgsConstructor
-    public static class Badge {
-        private String type;
-        private String tier;
-    }
-
-    @Getter @AllArgsConstructor
-    public static class AbandonBadge {
-        private Boolean IsGranted;
-        private Integer count;
-    }
 
     @Getter @Builder
     public static class LocationBlock {

--- a/src/main/java/goorm/ddok/member/service/AuthService.java
+++ b/src/main/java/goorm/ddok/member/service/AuthService.java
@@ -1,5 +1,6 @@
 package goorm.ddok.member.service;
 
+import goorm.ddok.badge.service.BadgeService;
 import goorm.ddok.global.exception.ErrorCode;
 import goorm.ddok.global.exception.GlobalException;
 import goorm.ddok.global.security.jwt.JwtTokenProvider;
@@ -47,6 +48,7 @@ public class AuthService {
     private final EmailVerificationService emailVerificationService;
     private final RefreshTokenService refreshTokenService;
     private final ReauthTokenService reauthTokenService;
+    private final BadgeService badgeService;
 
     private static final String PASSWORD_PATTERN = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[!@#$%]).{8,}$";
     private static final Pattern PASSWORD_REGEX = Pattern.compile(PASSWORD_PATTERN);
@@ -133,6 +135,10 @@ public class AuthService {
         if (!passwordEncoder.matches(request.getPassword(), user.getPassword())) {
             throw new GlobalException(ErrorCode.WRONG_PASSWORD);
         }
+
+        // 로그인 배지 반영 (1일 1회)
+        badgeService.grantLoginBadge(user);
+
 // 아직 이메일할 필요가 없으니까 이건 일단 빼놓고
 //        if (!user.isEmailVerified()) {
 //            emailVerificationService.handleEmailVerification(user.getEmail());

--- a/src/main/java/goorm/ddok/member/service/PlayerProfileService.java
+++ b/src/main/java/goorm/ddok/member/service/PlayerProfileService.java
@@ -1,5 +1,8 @@
 package goorm.ddok.member.service;
 
+import goorm.ddok.badge.service.BadgeService;
+import goorm.ddok.global.dto.AbandonBadgeDto;
+import goorm.ddok.global.dto.BadgeDto;
 import goorm.ddok.global.exception.ErrorCode;
 import goorm.ddok.global.exception.GlobalException;
 import goorm.ddok.global.security.auth.CustomUserDetails;
@@ -32,6 +35,7 @@ public class PlayerProfileService {
     private final TechStackRepository techStackRepository;
     private final UserReputationRepository userReputationRepository;
     private final UserPortfolioRepository userPortfolioRepository;
+    private final BadgeService badgeService;
 
     /* -------- 포지션 수정 -------- */
     public ProfileDto updatePositions(PositionsUpdateRequest req, CustomUserDetails me) {
@@ -277,6 +281,9 @@ public class PlayerProfileService {
 
         Long meId = (me != null && me.getUser() != null) ? me.getUser().getId() : null;
 
+        BadgeDto mainBadge = badgeService.getRepresentativeGoodBadge(fresh);
+        AbandonBadgeDto abandonBadge = badgeService.getAbandonBadge(fresh);
+
         // temperature (없으면 null)
         BigDecimal temp = userReputationRepository.findByUserId(fresh.getId())
                 .map(UserReputation::getTemperature)
@@ -335,8 +342,8 @@ public class PlayerProfileService {
                 .ageGroup(user.getAgeGroup())
                 .mainPosition(main)
                 .subPositions(subs)
-                .mainBadge(null)                // 요구사항: 없으면 null
-                .abandonBadge(null)             // 요구사항: 없으면 null
+                .mainBadge(mainBadge)                // 요구사항: 없으면 null
+                .abandonBadge(abandonBadge)             // 요구사항: 없으면 null
                 .activeHours(ah)
                 .traits(traits)
                 .content(fresh.getIntroduce())

--- a/src/main/java/goorm/ddok/player/service/ProfileQueryService.java
+++ b/src/main/java/goorm/ddok/player/service/ProfileQueryService.java
@@ -4,6 +4,7 @@ import goorm.ddok.badge.domain.BadgeTier;
 import goorm.ddok.badge.domain.BadgeTierRule;
 import goorm.ddok.badge.domain.BadgeType;
 import goorm.ddok.badge.repository.BadgeTierRuleRepository;
+import goorm.ddok.badge.service.BadgeService;
 import goorm.ddok.global.dto.AbandonBadgeDto;
 import goorm.ddok.global.dto.BadgeDto;
 import goorm.ddok.global.exception.ErrorCode;
@@ -29,10 +30,10 @@ import java.util.List;
 @Transactional(readOnly = true)
 public class ProfileQueryService {
 
-    private static final Logger log = LoggerFactory.getLogger(ProfileQueryService.class);
     private final UserRepository userRepository;
     private final UserPortfolioRepository userPortfolioRepository;
     private final BadgeTierRuleRepository badgeTierRuleRepository;
+    private final BadgeService badgeService;
 
     public ProfileDetailResponse getProfile(Long targetUserId, Long loginUserId) {
         User user = userRepository.findById(targetUserId)
@@ -157,14 +158,7 @@ public class ProfileQueryService {
     }
 
     private AbandonBadgeDto toAbandonBadgeDto(User user) {
-        return user.getBadges().stream()
-                .filter(badge -> badge.getBadgeType() == BadgeType.abandon && badge.getDeletedAt() == null)
-                .findFirst()
-                .map(AbandonBadgeDto::from)
-                .orElse(AbandonBadgeDto.builder()
-                        .IsGranted(false)
-                        .count(0)
-                        .build());
+        return badgeService.getAbandonBadge(user);
     }
 
     private boolean isGoodBadge(BadgeType type) {

--- a/src/main/java/goorm/ddok/player/service/ProfileSearchService.java
+++ b/src/main/java/goorm/ddok/player/service/ProfileSearchService.java
@@ -1,5 +1,8 @@
 package goorm.ddok.player.service;
 
+import goorm.ddok.badge.service.BadgeService;
+import goorm.ddok.global.dto.AbandonBadgeDto;
+import goorm.ddok.global.dto.BadgeDto;
 import goorm.ddok.member.domain.User;
 import goorm.ddok.member.domain.UserLocation;
 import goorm.ddok.member.domain.UserPosition;
@@ -28,6 +31,7 @@ import java.util.*;
 public class ProfileSearchService {
 
     private final UserRepository userRepository;
+    private final BadgeService badgeService;
 
     @Transactional(readOnly = true)
     public Page<ProfileSearchResponse> searchPlayers(String keyword, int page, int size, Long currentUserId) {
@@ -165,23 +169,31 @@ public class ProfileSearchService {
             mainPosition = pickMainPosition(u);
         }
 
+        // 대표 배지 조회
+        BadgeDto representative = badgeService.getRepresentativeGoodBadge(u);
+        ProfileSearchResponse.MainBadge mainBadge = null;
+        if (representative != null) {
+            mainBadge = ProfileSearchResponse.MainBadge.builder()
+                    .type(representative.getType().name())
+                    .tier(representative.getTier().name())
+                    .build();
+        }
+
+        // 나쁜 배지 조회
+        AbandonBadgeDto abandon = badgeService.getAbandonBadge(u);
+        ProfileSearchResponse.AbandonBadge abandonBadge =
+                ProfileSearchResponse.AbandonBadge.builder()
+                        .IsGranted(abandon.isIsGranted())
+                        .count(abandon.getCount())
+                        .build();
+
         return ProfileSearchResponse.builder()
                 .userId(u.getId())
                 .category("players")
                 .nickname(u.getNickname())
                 .profileImageUrl(u.getProfileImageUrl())
-                .mainBadge(ProfileSearchResponse
-                        .MainBadge
-                        .builder()
-                        .type("login")
-                        .tier("bronze")
-                        .build()) // TODO: 배지 도메인 연동
-                .abandonBadge(ProfileSearchResponse
-                        .AbandonBadge
-                        .builder()
-                        .IsGranted(true)
-                        .count(5)
-                        .build()) // TODO: 배지 도메인 연동
+                .mainBadge(mainBadge)
+                .abandonBadge(abandonBadge)
                 .mainPosition(mainPosition) // isPublic이 false이면 null
                 .address(address) // isPublic이 false이면 null
                 .temperature(36.5) // TODO: 평판/온도 도메인 연동

--- a/src/main/java/goorm/ddok/project/service/ProjectRecruitmentEditService.java
+++ b/src/main/java/goorm/ddok/project/service/ProjectRecruitmentEditService.java
@@ -1,5 +1,6 @@
 package goorm.ddok.project.service;
 
+import goorm.ddok.badge.service.BadgeService;
 import goorm.ddok.global.dto.AbandonBadgeDto;
 import goorm.ddok.global.dto.BadgeDto;
 import goorm.ddok.global.dto.LocationDto;
@@ -45,6 +46,8 @@ public class ProjectRecruitmentEditService {
     private final UserReputationRepository userReputationRepository;
     private final FileService fileService;
     private final BannerImageService bannerImageService;
+    private final BadgeService badgeService;
+
 
     /* =========================
      *  수정 페이지 조회 (상세와 동일 스키마)
@@ -498,8 +501,8 @@ public class ProjectRecruitmentEditService {
                 .map(BigDecimal::doubleValue)
                 .orElse(null);
 
-        BadgeDto mainBadge = fetchMainBadge(u.getId());
-        AbandonBadgeDto abandonBadge = fetchAbandonBadge(u.getId());
+        BadgeDto mainBadge = badgeService.getRepresentativeGoodBadge(u);
+        AbandonBadgeDto abandonBadge = badgeService.getAbandonBadge(u);
 
         return ProjectUpdateResultResponse.LeaderBlock.builder()
                 .userId(u.getId())
@@ -537,8 +540,8 @@ public class ProjectRecruitmentEditService {
                             .map(BigDecimal::doubleValue)
                             .orElse(null);
 
-                    BadgeDto mainBadge = fetchMainBadge(u.getId());
-                    AbandonBadgeDto abandonBadge = fetchAbandonBadge(u.getId());
+                    BadgeDto mainBadge = badgeService.getRepresentativeGoodBadge(u);
+                    AbandonBadgeDto abandonBadge = badgeService.getAbandonBadge(u);
 
                     return ProjectUpdateResultResponse.ParticipantBlock.builder()
                             .userId(u.getId())
@@ -571,8 +574,8 @@ public class ProjectRecruitmentEditService {
                 .map(UserReputation::getTemperature)
                 .orElse(null);
 
-        BadgeDto mainBadge = fetchMainBadge(u.getId());
-        AbandonBadgeDto abandonBadge = fetchAbandonBadge(u.getId());
+        BadgeDto mainBadge = badgeService.getRepresentativeGoodBadge(u);
+        AbandonBadgeDto abandonBadge = badgeService.getAbandonBadge(u);
 
         return ProjectUserSummaryDto.builder()
                 .userId(u.getId())
@@ -624,7 +627,4 @@ public class ProjectRecruitmentEditService {
         return s.isBlank() ? null : s;
     }
 
-    // === 배지 조회 Stub (실제 구현으로 교체 예정) ===
-    private BadgeDto fetchMainBadge(Long userId) { return null; }
-    private AbandonBadgeDto fetchAbandonBadge(Long userId) { return null; }
 }

--- a/src/main/java/goorm/ddok/project/service/ProjectRecruitmentQueryService.java
+++ b/src/main/java/goorm/ddok/project/service/ProjectRecruitmentQueryService.java
@@ -2,6 +2,7 @@ package goorm.ddok.project.service;
 
 import goorm.ddok.badge.domain.BadgeTier;
 import goorm.ddok.badge.domain.BadgeType;
+import goorm.ddok.badge.service.BadgeService;
 import goorm.ddok.global.dto.LocationDto;
 import goorm.ddok.global.dto.PreferredAgesDto;
 import goorm.ddok.global.dto.BadgeDto;
@@ -39,6 +40,8 @@ public class ProjectRecruitmentQueryService {
     private final ProjectParticipantRepository projectParticipantRepository;
     private final ProjectApplicationRepository projectApplicationRepository;
     private final UserReputationRepository userReputationRepository;
+    private final BadgeService badgeService;
+
 
     /** 프로젝트 모집글 상세 조회 */
     public ProjectDetailResponse getProjectDetail(Long projectId, CustomUserDetails userDetails) {
@@ -169,6 +172,10 @@ public class ProjectRecruitmentQueryService {
     private ProjectUserSummaryDto toUserSummaryDto(ProjectParticipant participant, User currentUser, BigDecimal temperature) {
         User user = participant.getUser();
 
+        BadgeDto mainBadge = badgeService.getRepresentativeGoodBadge(user);
+        AbandonBadgeDto abandonBadge = badgeService.getAbandonBadge(user);
+
+
         String mainPosition = user.getPositions().stream()
                 .filter(pos -> pos.getType() == UserPositionType.PRIMARY)
                 .map(UserPosition::getPositionName)
@@ -178,8 +185,6 @@ public class ProjectRecruitmentQueryService {
         Long meId = (currentUser != null) ? currentUser.getId() : null;
         Long otherId = user.getId();
 
-        BadgeDto mainBadge = resolveMainBadge(user);
-        AbandonBadgeDto abandonBadge = resolveAbandonBadge(user);
         Long chatRoomId = resolveChatRoomId(meId, otherId);
         boolean dmPending = resolveDmPending(meId, otherId);
 
@@ -188,8 +193,8 @@ public class ProjectRecruitmentQueryService {
                 .nickname(user.getNickname())
                 .profileImageUrl(user.getProfileImageUrl())
                 .mainPosition(mainPosition)
-                .mainBadge(BadgeDto.builder().type(BadgeType.login).tier(BadgeTier.bronze).build())
-                .abandonBadge(AbandonBadgeDto.builder().IsGranted(true).count(3).build())
+                .mainBadge(mainBadge)
+                .abandonBadge(abandonBadge)
                 .temperature(temperature)
                 .decidedPosition(participant.getPosition().getPositionName())
                 .IsMine(currentUser != null && user.getId().equals(currentUser.getId()))
@@ -233,8 +238,6 @@ public class ProjectRecruitmentQueryService {
     }
 
     // ==== 배지/DM/채팅방 기본 구현 (실서비스 연동 지점; 현재는 null 폴백) ====
-    private BadgeDto resolveMainBadge(User user) { return null; }
-    private AbandonBadgeDto resolveAbandonBadge(User user) { return null; }
     private Long resolveChatRoomId(Long meId, Long otherId) { return null; }
     private boolean resolveDmPending(Long meId, Long otherId) { return false; }
 }

--- a/src/main/java/goorm/ddok/study/service/StudyRecruitmentEditService.java
+++ b/src/main/java/goorm/ddok/study/service/StudyRecruitmentEditService.java
@@ -1,5 +1,6 @@
 package goorm.ddok.study.service;
 
+import goorm.ddok.badge.service.BadgeService;
 import goorm.ddok.global.dto.AbandonBadgeDto;
 import goorm.ddok.global.dto.BadgeDto;
 import goorm.ddok.global.dto.LocationDto;
@@ -47,6 +48,8 @@ public class StudyRecruitmentEditService {
     private final UserReputationRepository userReputationRepository;
     private final BannerImageService bannerImageService;
     private final FileService fileService;
+    private final BadgeService badgeService;
+
 
     /* =========================
      * 수정 페이지 조회 (상세 스키마 동일)
@@ -276,8 +279,8 @@ public class StudyRecruitmentEditService {
                 .map(UserReputation::getTemperature)
                 .orElse(null); // null 허용
 
-        BadgeDto mainBadge = null;
-        AbandonBadgeDto abandonBadge = null;
+        BadgeDto mainBadge =  badgeService.getRepresentativeGoodBadge(u);
+        AbandonBadgeDto abandonBadge = badgeService.getAbandonBadge(u);
 
         return UserSummaryDto.builder()
                 .userId(u.getId())

--- a/src/main/java/goorm/ddok/study/service/StudyRecruitmentQueryService.java
+++ b/src/main/java/goorm/ddok/study/service/StudyRecruitmentQueryService.java
@@ -2,6 +2,7 @@ package goorm.ddok.study.service;
 
 import goorm.ddok.badge.domain.BadgeTier;
 import goorm.ddok.badge.domain.BadgeType;
+import goorm.ddok.badge.service.BadgeService;
 import goorm.ddok.global.dto.AbandonBadgeDto;
 import goorm.ddok.global.dto.BadgeDto;
 import goorm.ddok.global.dto.LocationDto;
@@ -39,6 +40,8 @@ public class StudyRecruitmentQueryService {
     private final StudyParticipantRepository studyParticipantRepository;
     private final StudyApplicationRepository studyApplicationRepository;
     private final UserReputationRepository userReputationRepository;
+    private final BadgeService badgeService;
+
 
     /** 스터디 상세 조회 (수정페이지와 동일 스키마) */
     public StudyRecruitmentDetailResponse getStudyDetail(Long studyId, CustomUserDetails userDetails) {
@@ -135,6 +138,9 @@ public class StudyRecruitmentQueryService {
     private UserSummaryDto toUserSummaryDto(StudyParticipant participant, User me) {
         User u = participant.getUser();
 
+        BadgeDto mainBadge = badgeService.getRepresentativeGoodBadge(u);
+        AbandonBadgeDto abandonBadge = badgeService.getAbandonBadge(u);
+
         String mainPosition = u.getPositions().stream()
                 .filter(pos -> pos.getType() == UserPositionType.PRIMARY)
                 .map(UserPosition::getPositionName)
@@ -146,17 +152,13 @@ public class StudyRecruitmentQueryService {
                 .map(UserReputation::getTemperature)
                 .orElse(null);
 
-        // 뱃지: 아직 연동 전 → null
-        BadgeDto mainBadge = null;
-        AbandonBadgeDto abandonBadge = null;
-
         return UserSummaryDto.builder()
                 .userId(u.getId())
                 .nickname(u.getNickname())
                 .profileImageUrl(u.getProfileImageUrl())
                 .mainPosition(mainPosition)
-                .mainBadge(BadgeDto.builder().type(BadgeType.leader_complete).tier(BadgeTier.gold).build())
-                .abandonBadge(AbandonBadgeDto.builder().IsGranted(true).count(7).build())
+                .mainBadge(mainBadge)
+                .abandonBadge(abandonBadge)
                 .temperature(temperature)      // null 허용
                 .IsMine(me != null && Objects.equals(me.getId(), u.getId()))
                 .chatRoomId(null)

--- a/src/main/java/goorm/ddok/team/service/TeamMemberQueryService.java
+++ b/src/main/java/goorm/ddok/team/service/TeamMemberQueryService.java
@@ -124,10 +124,7 @@ public class TeamMemberQueryService {
      * @return {@link TeamApplicantUserResponse} 사용자 요약 정보
      */
     private TeamApplicantUserResponse toUserResponse(User user) {
-        BadgeDto mainBadge = badgeService.getGoodBadges(user).stream()
-                .max(Comparator.comparingInt(b -> b.getTier().ordinal()))
-                .orElse(null);
-
+        BadgeDto mainBadge = badgeService.getRepresentativeGoodBadge(user);
         AbandonBadgeDto abandonBadge = badgeService.getAbandonBadge(user);
 
         return TeamApplicantUserResponse.builder()


### PR DESCRIPTION
## 🔀 PR 제목
- [Refactor] 배지 시스템 적용 (프로필/팀/리크루트 서비스 연동)
- [Feature] 배지 부여 로직 추가 (로그인, 프로젝트/스터디 종료 시)
---

## 📌 작업 내용 요약
어떤 작업을 했는지 간략히 설명해주세요.

- 로그인 성공 시 login 배지 카운트 증가
- 프로젝트 종료 시 complete 배지 카운트 증가
  - 리더일 경우 leader_complete 배지도 카운트 증가
- 스터디 종료 시 complete 배지 카운트 증가
  - 리더일 경우 leader_complete 배지도 카운트 증가

- BadgeService에 대표 배지/탈주 배지 조회 메서드 추가 및 활용
  - 프로젝트/스터디 조회(QueryService, EditService) 시 대표 배지/탈주 배지 연동
  - 프로필 조회(ProfileQueryService, PlayerProfileService, ProfileSearchService)에서 배지 정보 반영
  - 팀 멤버/지원자 조회 시 배지 정보(mainBadge, abandonBadge) 노출

---

## ✅ 체크리스트
PR을 올리기 전에 아래 항목을 확인했나요?

- [x] 기능 요구사항을 모두 구현했나요?
- [x] 로컬에서 기능을 직접 테스트했나요? -> 스터디/프로젝트 종료 개발 후 추가 테스트 필요
- [x] 코드 컨벤션 및 스타일을 지켰나요?
- [x] 관련된 이슈에 연결했나요?

---

## 🔗 관련 이슈
`Closes #이슈번호` 또는 `Related to #이슈번호` 형태로 작성

- Closes #168 
- Related to #168 
---

## 📎 기타 참고 사항
추가로 리뷰어가 참고해야 할 사항이 있다면 적어주세요.

- 프로젝트/스터디 종료 하기 API 개발 시 BadgeService.grantCompleteBadge() 호출 부분 연동 필요 @vayaconChoi 
- 배지 관련 메서드 정리
  - `BadgeService.getGoodBadges(User user)`: 사용자의 착한 배지 리스트 조회
  - `BadgeService.getRepresentativeGoodBadge(User user)`: 사용자의 대표 배지(가장 높은 tier) 조회
  - `BadgeService.getAbandonBadge(User user)`: 사용자의 탈주 배지 조회