### PR TITLE
feat(소설 로그인 시 기존의 프로필 이미지 조회): 소설 로그인 시 기존의 프로필 이미지 조회 DP-362

### DIFF
--- a/src/main/java/goorm/ddok/member/service/SocialAuthService.java
+++ b/src/main/java/goorm/ddok/member/service/SocialAuthService.java
@@ -71,7 +71,8 @@ public class SocialAuthService {
         if (email != null && !email.isBlank() && !email.equals(u.getEmail())) {
             u.setEmail(email);
         }
-        if (profileImageUrl != null && !profileImageUrl.isBlank()) {
+        if ((u.getProfileImageUrl() == null || u.getProfileImageUrl().isBlank())
+                && profileImageUrl != null && !profileImageUrl.isBlank()) {
             u.setProfileImageUrl(profileImageUrl);
         }
     }


### PR DESCRIPTION
## 🔀 PR 제목
- [Fix] 소설 로그인 시 기존의 프로필 이미지 조회


---

## 📌 작업 내용 요약
어떤 작업을 했는지 간략히 설명해주세요.

- 소설 로그인 시 기존의 프로필 이미지 조회

---

## ✅ 체크리스트
PR을 올리기 전에 아래 항목을 확인했나요?

- [ ] 기능 요구사항을 모두 구현했나요?
- [ ] 로컬에서 기능을 직접 테스트했나요?
- [ ] 코드 컨벤션 및 스타일을 지켰나요?
- [ ] 관련된 이슈에 연결했나요?

---

## 🔗 관련 이슈
`Closes #이슈번호` 또는 `Related to #이슈번호` 형태로 작성

예시:
- Closes #177 
- Related to #177
---

## 📎 기타 참고 사항
추가로 리뷰어가 참고해야 할 사항이 있다면 적어주세요.

예시:
-테스트
<img width="2522" height="675" alt="image" src="https://github.com/user-attachments/assets/ba398c9f-9b52-4bc8-a898-b1e780206b97" />
<img width="59" height="57" alt="image" src="https://github.com/user-attachments/assets/f4787e0b-922f-4b1f-a0c4-10c3f79e46d2" />

