### PR TITLE
[Fix] 프로필 지도 및 프로젝트,스터디 모집 수정

### DIFF
--- a/src/main/java/goorm/ddok/map/service/MapService.java
+++ b/src/main/java/goorm/ddok/map/service/MapService.java
@@ -31,9 +31,6 @@ public class MapService {
     private final CafeRepository cafeRepository;
     private final BadgeService badgeService;
 
-
-    private static final Double DEFAULT_TEMPERATURE = 36.5;
-
     public List<AllMapItemResponse> getAllInBounds(
             BigDecimal swLat, BigDecimal swLng,
             BigDecimal neLat, BigDecimal neLng,

--- a/src/main/java/goorm/ddok/member/service/PlayerProfileMapService.java
+++ b/src/main/java/goorm/ddok/member/service/PlayerProfileMapService.java
@@ -5,6 +5,7 @@ import goorm.ddok.global.exception.ErrorCode;
 import goorm.ddok.global.exception.GlobalException;
 import goorm.ddok.member.dto.response.PlayerProfileMapItemResponse;
 import goorm.ddok.member.repository.UserRepository;
+import goorm.ddok.project.domain.TeamStatus;
 import goorm.ddok.project.repository.ProjectRecruitmentRepository;
 import goorm.ddok.study.repository.StudyRecruitmentRepository;
 import lombok.RequiredArgsConstructor;
@@ -43,7 +44,7 @@ public class PlayerProfileMapService {
                     .category("project")
                     .projectId(r.getId())
                     .title(r.getTitle())
-                    .teamStatus(r.getTeamStatus().toString())
+                    .teamStatus(normalizeProjectTeamStatus(r.getTeamStatus()))
                     .location(LocationDto.builder()
                             .address(composeRoadAddress(
                                     r.getRegion1depthName(),
@@ -72,7 +73,7 @@ public class PlayerProfileMapService {
                     .category("study")
                     .studyId(r.getId())
                     .title(r.getTitle())
-                    .teamStatus(r.getTeamStatus().toString())
+                    .teamStatus(normalizeStudyTeamStatus(r.getTeamStatus()))
                     .location(LocationDto.builder()
                             .address(composeRoadAddress(
                                     r.getRegion1depthName(),
@@ -153,6 +154,16 @@ public class PlayerProfileMapService {
         if (hasAll && (swLat.compareTo(neLat) > 0 || swLng.compareTo(neLng) > 0)) {
             throw new GlobalException(ErrorCode.INVALID_MAP_BOUNDS);
         }
+    }
+
+    private String normalizeProjectTeamStatus(goorm.ddok.project.domain.TeamStatus status) {
+        if (status == null) return "ONGOING";
+        return (status == TeamStatus.RECRUITING) ? "ONGOING" : status.name();
+    }
+
+    private String normalizeStudyTeamStatus(goorm.ddok.study.domain.TeamStatus status) {
+        if (status == null) return "ONGOING";
+        return (status == goorm.ddok.study.domain.TeamStatus.RECRUITING) ? "ONGOING" : status.name();
     }
 
 }

--- a/src/main/java/goorm/ddok/project/repository/ProjectApplicationRepository.java
+++ b/src/main/java/goorm/ddok/project/repository/ProjectApplicationRepository.java
@@ -19,8 +19,8 @@ public interface ProjectApplicationRepository extends JpaRepository<ProjectAppli
     /**
      * 특정 모집글(ProjectRecruitment)에 대한 전체 지원자 수 조회
      */
-    int countByPosition_ProjectRecruitment(ProjectRecruitment recruitment);
-
+    int countByPosition_ProjectRecruitmentAndStatusNot(
+            ProjectRecruitment recruitment, ApplicationStatus status);
 
     /** 프로젝트 기준 전체 지원 수 */
     @Query("""
@@ -55,7 +55,7 @@ public interface ProjectApplicationRepository extends JpaRepository<ProjectAppli
     /**
      * 특정 포지션(ProjectRecruitmentPosition)에 대한 지원자 수 조회
      */
-    int countByPosition(ProjectRecruitmentPosition position);
+    int countByPositionAndStatusNot(ProjectRecruitmentPosition position, ApplicationStatus status);
 
     /**
      * 특정 유저(userId)가 특정 모집글(projectId)에 지원했는지 여부 확인
@@ -109,6 +109,7 @@ public interface ProjectApplicationRepository extends JpaRepository<ProjectAppli
                 goorm.ddok.project.domain.ApplicationStatus.REJECTED
         );
     }
+
 }
 
 

--- a/src/main/java/goorm/ddok/project/repository/ProjectRecruitmentRepository.java
+++ b/src/main/java/goorm/ddok/project/repository/ProjectRecruitmentRepository.java
@@ -84,8 +84,6 @@ public interface ProjectRecruitmentRepository extends JpaRepository<ProjectRecru
     where pp.deletedAt is null
       and pr.deletedAt is null
       and pp.user.id = :userId
-      and pr.teamStatus in (goorm.ddok.project.domain.TeamStatus.ONGOING,
-                            goorm.ddok.project.domain.TeamStatus.CLOSED)
       and pr.latitude  is not null
       and pr.longitude is not null
       and pr.latitude  between :swLat and :neLat

--- a/src/main/java/goorm/ddok/project/service/ProjectRecruitmentQueryService.java
+++ b/src/main/java/goorm/ddok/project/service/ProjectRecruitmentQueryService.java
@@ -65,7 +65,8 @@ public class ProjectRecruitmentQueryService {
                 .orElseThrow(() -> new GlobalException(ErrorCode.LEADER_NOT_FOUND));
 
         // 4) 총 지원자 수
-        int applicantCount = projectApplicationRepository.countByPosition_ProjectRecruitment(project);
+        int applicantCount = projectApplicationRepository
+                .countByPosition_ProjectRecruitmentAndStatusNot(project, ApplicationStatus.REJECTED);
 
         // 5) 포지션별 현황
         List<ProjectPositionDto> positionDtos = project.getPositions().stream()
@@ -74,7 +75,8 @@ public class ProjectRecruitmentQueryService {
                             .filter(p -> p.getRole() == ParticipantRole.MEMBER && Objects.equals(p.getPosition(), position))
                             .count();
 
-                    int appliedCountForPos = projectApplicationRepository.countByPosition(position);
+                    int appliedCountForPos =
+                            projectApplicationRepository.countByPositionAndStatusNot(position, ApplicationStatus.REJECTED);
 
                     boolean isApplied =
                             (me != null) &&
@@ -88,7 +90,8 @@ public class ProjectRecruitmentQueryService {
                                     me.getId(), position.getId(), ParticipantRole.MEMBER);
 
                     boolean alreadyAppliedOtherPos = (me != null) &&
-                            projectApplicationRepository.existsByUser_IdAndPosition_ProjectRecruitment_Id(me.getId(), project.getId())
+                            (projectApplicationRepository.existsByUser_IdAndPosition_ProjectRecruitment_IdAndStatus(me.getId(), project.getId(), ApplicationStatus.PENDING) ||
+                            projectApplicationRepository.existsByUser_IdAndPosition_ProjectRecruitment_IdAndStatus(me.getId(), project.getId(), ApplicationStatus.APPROVED))
                             && !isApplied;
 
                     boolean hasPendingInProject =

--- a/src/main/java/goorm/ddok/project/service/ProjectRecruitmentService.java
+++ b/src/main/java/goorm/ddok/project/service/ProjectRecruitmentService.java
@@ -342,7 +342,6 @@ public class ProjectRecruitmentService {
                     existing.setStatus(ApplicationStatus.PENDING);
                     projectApplicationRepository.save(existing);
 
-                    // 🔔 이벤트 발행 (AFTER_COMMIT에서 푸시)
                     eventPublisher.publishEvent(
                             ProjectJoinRequestedEvent.builder()
                                     .applicationId(existing.getId())

--- a/src/main/java/goorm/ddok/project/service/ProjectRecruitmentService.java
+++ b/src/main/java/goorm/ddok/project/service/ProjectRecruitmentService.java
@@ -8,7 +8,6 @@ import goorm.ddok.global.file.FileService;
 import goorm.ddok.global.security.auth.CustomUserDetails;
 import goorm.ddok.global.util.BannerImageService;
 import goorm.ddok.member.domain.User;
-import goorm.ddok.notification.event.ProjectJoinRequestDecisionEvent;
 import goorm.ddok.notification.event.ProjectJoinRequestedEvent;
 import goorm.ddok.project.domain.*;
 import goorm.ddok.project.dto.request.ProjectRecruitmentCreateRequest;

--- a/src/main/java/goorm/ddok/study/repository/StudyApplicationRepository.java
+++ b/src/main/java/goorm/ddok/study/repository/StudyApplicationRepository.java
@@ -15,7 +15,8 @@ import java.util.Optional;
 public interface StudyApplicationRepository extends JpaRepository<StudyApplication, Long> {
 
     /** 특정 모집글(StudyRecruitment)에 대한 전체 지원자 수 조회 */
-    long countByStudyRecruitment(StudyRecruitment study);
+    long countByStudyRecruitmentAndApplicationStatusNot(
+            StudyRecruitment study, goorm.ddok.study.domain.ApplicationStatus status);
 
     /** 특정 유저(userId)가 특정 스터디 모집글(studyId)에 지원했는지 여부 확인 */
     Optional<StudyApplication> findByUser_IdAndStudyRecruitment_Id(Long userId, Long studyId);

--- a/src/main/java/goorm/ddok/study/repository/StudyRecruitmentRepository.java
+++ b/src/main/java/goorm/ddok/study/repository/StudyRecruitmentRepository.java
@@ -89,8 +89,6 @@ public interface StudyRecruitmentRepository extends JpaRepository<StudyRecruitme
     where sp.deletedAt is null
       and sr.deletedAt is null
       and sp.user.id = :userId
-      and sr.teamStatus in (goorm.ddok.study.domain.TeamStatus.ONGOING,
-                            goorm.ddok.study.domain.TeamStatus.CLOSED)
       and sr.latitude  is not null
       and sr.longitude is not null
       and sr.latitude  between :swLat and :neLat

--- a/src/main/java/goorm/ddok/study/service/StudyRecruitmentEditService.java
+++ b/src/main/java/goorm/ddok/study/service/StudyRecruitmentEditService.java
@@ -12,11 +12,7 @@ import goorm.ddok.global.exception.GlobalException;
 import goorm.ddok.global.file.FileService;
 import goorm.ddok.global.security.auth.CustomUserDetails;
 import goorm.ddok.global.util.BannerImageService;
-import goorm.ddok.study.domain.ParticipantRole;
-import goorm.ddok.study.domain.StudyMode;
-import goorm.ddok.study.domain.StudyParticipant;
-import goorm.ddok.study.domain.StudyRecruitment;
-import goorm.ddok.study.domain.StudyRecruitmentTrait;
+import goorm.ddok.study.domain.*;
 import goorm.ddok.study.dto.UserSummaryDto;
 import goorm.ddok.study.dto.request.StudyRecruitmentUpdateRequest;
 import goorm.ddok.study.dto.response.StudyRecruitmentDetailResponse;
@@ -173,7 +169,8 @@ public class StudyRecruitmentEditService {
                 .filter(p -> p.getRole() == ParticipantRole.MEMBER)
                 .toList();
 
-        int applicantCount = (int) studyApplicationRepository.countByStudyRecruitment(study);
+        int applicantCount = (int) studyApplicationRepository
+                .countByStudyRecruitmentAndApplicationStatusNot(study, ApplicationStatus.REJECTED);
         int participantsCount = members.size();
 
         UserSummaryDto leaderDto = toUserSummaryDto(leader, me);

--- a/src/main/java/goorm/ddok/study/service/StudyRecruitmentQueryService.java
+++ b/src/main/java/goorm/ddok/study/service/StudyRecruitmentQueryService.java
@@ -68,7 +68,8 @@ public class StudyRecruitmentQueryService {
                 .filter(p -> p.getRole() == ParticipantRole.MEMBER)
                 .toList();
         int participantsCount = members.size();
-        int applicantCount = (int) studyApplicationRepository.countByStudyRecruitment(study);
+        int applicantCount = (int) studyApplicationRepository
+                .countByStudyRecruitmentAndApplicationStatusNot(study, ApplicationStatus.REJECTED);
 
         // 5) 리더/멤버 요약 (온도/뱃지 없으면 null)
         UserSummaryDto leaderDto = toUserSummaryDto(leader, me);


### PR DESCRIPTION
## 🔀 PR 제목

- [Fix] 프로필 지도 수정
- [Fix] 프로젝트 지원 불가 현상 수정
- [Fix] 하차 및 추방 인원이 지원자에 집계되는 현상 수정
 

---

## 📌 작업 내용 요약

- 프로젝트에서 추방 및 하차 시 재지원 가능하게 수정
- 프로젝트/스터디 지원자 수에서 추방/하차 인원 제외
- 프로필 지도에서 CLOSED된 프로젝트 스터디만 보이던 현상 수정
- 모든 상태를 다 보여주되 모집중은 진행중으로 보여줌

---

## ✅ 체크리스트
PR을 올리기 전에 아래 항목을 확인했나요?

- [ ] 기능 요구사항을 모두 구현했나요?
- [ ] 로컬에서 기능을 직접 테스트했나요?
- [ ] 코드 컨벤션 및 스타일을 지켰나요?
- [ ] 관련된 이슈에 연결했나요?

---

## 🔗 관련 이슈

- Closes #217 

---

