### PR TITLE
[Feature] 채팅 안 읽은 메세지 실시간 알림

### DIFF
--- a/src/main/java/goorm/ddok/chat/dto/response/ChatRoomResponse.java
+++ b/src/main/java/goorm/ddok/chat/dto/response/ChatRoomResponse.java
@@ -49,6 +49,9 @@ public class ChatRoomResponse {
     @Schema(description = "마지막 메시지")
     private LastMessageResponse lastMessage;
 
+    @Schema(description = "안 읽은 메시지 존재 여부", example = "true")
+    private Boolean hasUnreadMessages;
+
     @Schema(description = "마지막 업데이트 시간")
     private Instant updatedAt;
 }

--- a/src/main/java/goorm/ddok/chat/repository/ChatRoomMemberRepository.java
+++ b/src/main/java/goorm/ddok/chat/repository/ChatRoomMemberRepository.java
@@ -52,8 +52,18 @@ public interface ChatRoomMemberRepository extends JpaRepository<ChatRoomMember, 
            and user_id = :userId
          order by id desc
          limit 1
-        """, nativeQuery = true)
+    """, nativeQuery = true)
     Optional<ChatRoomMember> findLatestIncludingDeleted(@Param("roomId") Long roomId,
                                                         @Param("userId") Long userId);
 
+    @Query("""
+          select m from ChatRoomMember m
+          where m.room.id = :roomId
+            and m.deletedAt is null
+            and m.user.id <> :senderId
+        """)
+    List<ChatRoomMember> findActiveMembersExcludingSender(@Param("roomId") Long roomId,
+                                                          @Param("senderId") Long senderId);
+
 }
+

--- a/src/main/java/goorm/ddok/chat/service/ChatNotificationService.java
+++ b/src/main/java/goorm/ddok/chat/service/ChatNotificationService.java
@@ -1,0 +1,42 @@
+package goorm.ddok.chat.service;
+
+import goorm.ddok.chat.domain.ChatRoomMember;
+import goorm.ddok.chat.dto.response.ChatMessageResponse;
+import goorm.ddok.chat.repository.ChatRoomMemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.*;
+
+@Service
+@RequiredArgsConstructor
+public class ChatNotificationService {
+
+    private final SimpMessagingTemplate messagingTemplate;
+    private final ChatRoomMemberRepository memberRepo;
+
+    public void notifyNewMessage(ChatMessageResponse saved) {
+
+        Long roomId = saved.getRoomId();
+        Long senderId = saved.getSenderId();
+
+        // 멤버 조회
+        List<ChatRoomMember> members =
+                memberRepo.findActiveMembersExcludingSender(roomId, senderId == null ? -1L : senderId);
+
+        for (ChatRoomMember m : members) {
+            Long userId = m.getUser().getId();
+
+            Map<String, Object> payload = Map.of(
+                    "type", "NEW_MESSAGE_FLAG",
+                    "roomId", roomId
+            );
+
+            String destination = "/sub/users/" + userId + "/notifications";
+            messagingTemplate.convertAndSend(destination, payload);
+        }
+    }
+
+
+}

--- a/src/main/java/goorm/ddok/chat/util/ChatMapper.java
+++ b/src/main/java/goorm/ddok/chat/util/ChatMapper.java
@@ -47,6 +47,7 @@ public class ChatMapper {
         ChatRoomResponse.ChatRoomResponseBuilder builder = ChatRoomResponse.builder()
                 .roomId(chatRoom.getId())
                 .roomType(chatRoom.getRoomType())
+                .hasUnreadMessages(chatRepository.hasUnreadByTime(chatRoom.getId(), currentUserId))
                 .isPinned(false) // TODO: 고정 기능 구현 시 실제 값으로 변경
                 .updatedAt(Optional.ofNullable(chatRoom.getLastMessageAt())
                         .orElse(chatRoom.getCreatedAt()));

--- a/src/main/java/goorm/ddok/chat/ws/ChatWsController.java
+++ b/src/main/java/goorm/ddok/chat/ws/ChatWsController.java
@@ -1,9 +1,12 @@
 package goorm.ddok.chat.ws;
 
 import goorm.ddok.chat.domain.ChatContentType;
+import goorm.ddok.chat.domain.ChatRoomMember;
 import goorm.ddok.chat.dto.request.ChatMessageRequest;
 import goorm.ddok.chat.dto.response.ChatMessageResponse;
+import goorm.ddok.chat.repository.ChatRoomMemberRepository;
 import goorm.ddok.chat.service.ChatMessageService;
+import goorm.ddok.chat.service.ChatNotificationService;
 import goorm.ddok.global.exception.ErrorCode;
 import goorm.ddok.global.exception.GlobalException;
 import goorm.ddok.member.domain.User;
@@ -14,6 +17,7 @@ import org.springframework.messaging.handler.annotation.*;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Controller;
 
+import java.util.List;
 import java.util.Map;
 
 @Slf4j
@@ -24,6 +28,7 @@ public class ChatWsController {
     private final ChatMessageService chatMessageService;
     private final SimpMessagingTemplate messagingTemplate;
     private final UserRepository userRepository;
+    private final ChatNotificationService chatNotificationService;
 
     /**
      * 클라 SEND: /pub/chats/{roomId}/send
@@ -47,6 +52,8 @@ public class ChatWsController {
         ChatMessageResponse saved = chatMessageService.sendMessage(userId, roomId, payload);
 
         messagingTemplate.convertAndSend("/sub/chats/" + roomId, saved);
+
+        chatNotificationService.notifyNewMessage(saved);
     }
 
     @MessageMapping("/chats/{roomId}/enter")

--- a/src/main/java/goorm/ddok/global/websocket/StompPrincipal.java
+++ b/src/main/java/goorm/ddok/global/websocket/StompPrincipal.java
@@ -1,0 +1,9 @@
+package goorm.ddok.global.websocket;
+
+import java.security.Principal;
+
+public class StompPrincipal implements Principal {
+    private final String name;
+    public StompPrincipal(String name) { this.name = name; }
+    @Override public String getName() { return name; }
+}


### PR DESCRIPTION
## 🔀 PR 제목
[Feature] 채팅 안 읽은 메세지 실시간 알림

---

## 📌 작업 내용 요약
채팅방 메세지 읽음 여부 추가
웹소켓으로 채팅방 새로운 메세지 알림 추가

---

## ✅ 체크리스트
PR을 올리기 전에 아래 항목을 확인했나요?

- [x] 기능 요구사항을 모두 구현했나요?
- [x] 로컬에서 기능을 직접 테스트했나요?
- [x] 코드 컨벤션 및 스타일을 지켰나요?
- [x] 관련된 이슈에 연결했나요?

---

## 🔗 관련 이슈
Closes #225 

---

## 📎 기타 참고 사항
<img width="1322" height="721" alt="image" src="https://github.com/user-attachments/assets/d4c125da-d307-43a8-a887-d64da6e13426" />

본인 제외 전체 멤버에게 메시지를 전송하는 방식으로 구현했습니다.
구독 상태인 경우에만 메시지를 수신하며, 구독하지 않으면 수신되지 않습니다.
