### PR TITLE
Fix/dp 350 location

### DIFF
--- a/src/main/java/goorm/ddok/global/dto/PreferredAgesDto.java
+++ b/src/main/java/goorm/ddok/global/dto/PreferredAgesDto.java
@@ -16,4 +16,12 @@ public class PreferredAgesDto {
 
     @Schema(description = "최대 연령 (무관 시 null)", example = "30")
     private Integer ageMax;
+
+    public static PreferredAgesDto of(Integer min, Integer max) {
+        if (min == null && max == null) return null;
+        return PreferredAgesDto.builder()
+                .ageMin(min)
+                .ageMax(max)
+                .build();
+    }
 }

--- a/src/main/java/goorm/ddok/map/service/MapService.java
+++ b/src/main/java/goorm/ddok/map/service/MapService.java
@@ -691,10 +691,7 @@ public class MapService {
                 .capacity(row.getCapacity())
                 .mode(row.getMode().toString())
                 .address(row.getAddress())
-                .preferredAges(PreferredAgesDto.builder()
-                        .ageMin(row.getAgeMin())
-                        .ageMax(row.getAgeMax())
-                        .build())
+                .preferredAges(PreferredAgesDto.of(row.getAgeMin(), row.getAgeMax()))
                 .expectedMonth(row.getExpectedMonth())
                 .startDate(row.getStartDate())
                 .build();
@@ -714,10 +711,7 @@ public class MapService {
                 .capacity(row.getCapacity())
                 .mode(row.getMode().toString())
                 .address(row.getAddress())
-                .preferredAges(PreferredAgesDto.builder()
-                        .ageMin(row.getAgeMin())
-                        .ageMax(row.getAgeMax())
-                        .build())
+                .preferredAges(PreferredAgesDto.of(row.getAgeMin(), row.getAgeMax()))
                 .expectedMonth(row.getExpectedMonth())
                 .startDate(row.getStartDate())
                 .build();

--- a/src/main/java/goorm/ddok/player/dto/response/ProjectLocationResponse.java
+++ b/src/main/java/goorm/ddok/player/dto/response/ProjectLocationResponse.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.math.BigDecimal;
+import java.util.Optional;
 
 @Getter
 @NoArgsConstructor
@@ -44,12 +45,19 @@ public class ProjectLocationResponse {
     private BigDecimal longitude;
 
     public static ProjectLocationResponse from(ProjectRecruitment project) {
-        String region1 = project.getRegion1depthName() != null ? project.getRegion1depthName() : "";
-        String region2 = project.getRegion2depthName() != null ? project.getRegion2depthName() : "";
-        String address = normalizeRegion1(region1) + " " + region2;
+        if (project == null) return null;
+
+        String r1 = Optional.ofNullable(project.getRegion1depthName()).orElse("").trim();
+        String r2 = Optional.ofNullable(project.getRegion2depthName()).orElse("").trim();
+
+        StringBuilder sb = new StringBuilder();
+        if (!r1.isEmpty()) sb.append(r1).append(" ");
+        if (!r2.isEmpty()) sb.append(r2);
+
+        String address = sb.toString().trim().replaceAll("\\s+", " ");
 
         return ProjectLocationResponse.builder()
-                .address(address)
+                .address(address.isBlank() ? null : address)
                 .region1depthName(project.getRegion1depthName())
                 .region2depthName(project.getRegion2depthName())
                 .region3depthName(project.getRegion3depthName())
@@ -60,14 +68,6 @@ public class ProjectLocationResponse {
                 .latitude(project.getLatitude())
                 .longitude(project.getLongitude())
                 .build();
-    }
-
-    private static String normalizeRegion1(String region1) {
-        return region1.replace("특별시", "")
-                .replace("광역시", "")
-                .replace("자치시", "")
-                .replace("도", "")
-                .trim();
     }
 
 }

--- a/src/main/java/goorm/ddok/player/dto/response/ProjectParticipationResponse.java
+++ b/src/main/java/goorm/ddok/player/dto/response/ProjectParticipationResponse.java
@@ -23,9 +23,16 @@ import lombok.NoArgsConstructor;
           "title": "구지라지 프로젝트",
           "teamStatus": "CLOSED",
           "location": {
-            "latitude": 37.5665,
-            "longitude": 126.9780,
-            "address": "서울특별시 강남구 테헤란로…"
+          "address": "전북 익산시",
+            "region1depthName": "전북",
+            "region2depthName": "익산시",
+            "region3depthName": "부송동",
+            "roadName": "망산길",
+            "mainBuildingNo": "11",
+            "subBuildingNo": "17",
+            "zoneNo": "54547",
+            "latitude": 35.976749396987046,
+            "longitude": 126.99599512792346
           },
           "period": {
             "start": "2025-08-01",

--- a/src/main/java/goorm/ddok/player/dto/response/StudyLocationResponse.java
+++ b/src/main/java/goorm/ddok/player/dto/response/StudyLocationResponse.java
@@ -45,12 +45,19 @@ public class StudyLocationResponse {
     private BigDecimal longitude;
 
     public static StudyLocationResponse from(StudyRecruitment study) {
-        String region1 = study.getRegion1depthName() != null ? study.getRegion1depthName() : "";
-        String region2 = study.getRegion2depthName() != null ? study.getRegion2depthName() : "";
-        String address = normalizeRegion1(region1) + " " + region2;
+        if (study == null) return null;
+
+        String r1 = study.getRegion1depthName() != null ? study.getRegion1depthName().trim() : "";
+        String r2 = study.getRegion2depthName() != null ? study.getRegion2depthName().trim() : "";
+
+        StringBuilder sb = new StringBuilder();
+        if (!r1.isEmpty()) sb.append(r1).append(" ");
+        if (!r2.isEmpty()) sb.append(r2);
+
+        String address = sb.toString().trim().replaceAll("\\s+", " ");
 
         return StudyLocationResponse.builder()
-                .address(address)
+                .address(address.isBlank() ? null : address)
                 .region1depthName(study.getRegion1depthName())
                 .region2depthName(study.getRegion2depthName())
                 .region3depthName(study.getRegion3depthName())
@@ -63,11 +70,4 @@ public class StudyLocationResponse {
                 .build();
     }
 
-    private static String normalizeRegion1(String region1) {
-        return region1.replace("특별시", "")
-                .replace("광역시", "")
-                .replace("자치시", "")
-                .replace("도", "")
-                .trim();
-    }
 }

--- a/src/main/java/goorm/ddok/project/service/ProjectListService.java
+++ b/src/main/java/goorm/ddok/project/service/ProjectListService.java
@@ -200,10 +200,7 @@ public class ProjectListService {
                 .capacity(p.getCapacity())
                 .mode(p.getProjectMode())
                 .address(address)
-                .preferredAges(PreferredAgesDto.builder()
-                        .ageMin(p.getAgeMin())
-                        .ageMax(p.getAgeMax())
-                        .build())
+                .preferredAges(PreferredAgesDto.of(p.getAgeMin(), p.getAgeMax()))
                 .expectedMonth(p.getExpectedMonths())
                 .startDate(p.getStartDate())
                 .build();

--- a/src/main/java/goorm/ddok/project/service/ProjectRecruitmentEditService.java
+++ b/src/main/java/goorm/ddok/project/service/ProjectRecruitmentEditService.java
@@ -128,9 +128,10 @@ public class ProjectRecruitmentEditService {
                 .map(p -> toUserSummaryDto(p, me.getUser()))
                 .toList();
 
-        PreferredAgesDto ages = (pr.getAgeMin() == 0 && pr.getAgeMax() == 0)
-                ? null
-                : PreferredAgesDto.builder().ageMin(pr.getAgeMin()).ageMax(pr.getAgeMax()).build();
+        PreferredAgesDto ages = PreferredAgesDto.of(
+                (pr.getAgeMin() == 0 ? null : pr.getAgeMin()),
+                (pr.getAgeMax() == 0 ? null : pr.getAgeMax())
+        );
 
         return ProjectDetailResponse.builder()
                 .projectId(pr.getId())
@@ -450,10 +451,10 @@ public class ProjectRecruitmentEditService {
         boolean isMine = meId != null && Objects.equals(pr.getUser().getId(), meId);
 
         // 무관(0/0)일 때 null
-        PreferredAgesDto prefAges =
-                (pr.getAgeMin() == 0 && pr.getAgeMax() == 0)
-                        ? null
-                        : new PreferredAgesDto(pr.getAgeMin(), pr.getAgeMax());
+        PreferredAgesDto prefAges = PreferredAgesDto.of(
+                (pr.getAgeMin() == 0 ? null : pr.getAgeMin()),
+                (pr.getAgeMax() == 0 ? null : pr.getAgeMax())
+        );
 
         // 리더/참여자 조회
         List<ProjectParticipant> participants =

--- a/src/main/java/goorm/ddok/project/service/ProjectRecruitmentQueryService.java
+++ b/src/main/java/goorm/ddok/project/service/ProjectRecruitmentQueryService.java
@@ -145,13 +145,11 @@ public class ProjectRecruitmentQueryService {
         LocationDto location = buildLocationForRead(project);
 
         // 8) 선호 연령 (0/0이면 null)
-        PreferredAgesDto ages =
-                (isZero(project.getAgeMin()) && isZero(project.getAgeMax()))
-                        ? null
-                        : PreferredAgesDto.builder()
-                        .ageMin(project.getAgeMin())
-                        .ageMax(project.getAgeMax())
-                        .build();
+        PreferredAgesDto ages = PreferredAgesDto.of(
+                isZero(project.getAgeMin()) ? null : project.getAgeMin(),
+                isZero(project.getAgeMax()) ? null : project.getAgeMax()
+        );
+
 
         Optional<Team> team = teamRepository.findByRecruitmentIdAndType(project.getId(), TeamType.PROJECT);
 

--- a/src/main/java/goorm/ddok/project/service/ProjectRecruitmentService.java
+++ b/src/main/java/goorm/ddok/project/service/ProjectRecruitmentService.java
@@ -221,12 +221,10 @@ public class ProjectRecruitmentService {
         }
 
         // preferredAges: 0/0(무관) → null 로 응답
-        PreferredAgesDto respAges = PreferredAgesDto.builder()
-                .ageMin(recruitment.getAgeMin())
-                .ageMax(recruitment.getAgeMax())
-                .build();
-
-
+        PreferredAgesDto respAges = PreferredAgesDto.of(
+                recruitment.getAgeMin(),
+                recruitment.getAgeMax()
+        );
 
         return ProjectRecruitmentResponse.builder()
                 .projectId(recruitment.getId())

--- a/src/main/java/goorm/ddok/study/service/StudyListService.java
+++ b/src/main/java/goorm/ddok/study/service/StudyListService.java
@@ -271,10 +271,10 @@ public class StudyListService {
                 .mode(s.getMode())
                 .address(address)
                 .studyType(s.getStudyType())
-                .preferredAges(PreferredAgesDto.builder()
-                        .ageMin(s.getAgeMin())
-                        .ageMax(s.getAgeMax())
-                        .build())
+                .preferredAges(PreferredAgesDto.of(
+                        (s.getAgeMin() != null && s.getAgeMin() == 0) ? null : s.getAgeMin(),
+                        (s.getAgeMax() != null && s.getAgeMax() == 0) ? null : s.getAgeMax()
+                ))
                 .expectedMonth(s.getExpectedMonths())
                 .startDate(s.getStartDate())
                 .build();

--- a/src/main/java/goorm/ddok/study/service/StudyRecruitmentEditService.java
+++ b/src/main/java/goorm/ddok/study/service/StudyRecruitmentEditService.java
@@ -179,9 +179,10 @@ public class StudyRecruitmentEditService {
                 .map(p -> toUserSummaryDto(p, me))
                 .toList();
 
-        PreferredAgesDto ages = (isZero(study.getAgeMin()) && isZero(study.getAgeMax()))
-                ? null
-                : new PreferredAgesDto(study.getAgeMin(), study.getAgeMax());
+        PreferredAgesDto ages = PreferredAgesDto.of(
+                study.getAgeMin(),
+                study.getAgeMax()
+        );
 
         LocationDto location = buildLocationForRead(study);
 

--- a/src/main/java/goorm/ddok/study/service/StudyRecruitmentQueryService.java
+++ b/src/main/java/goorm/ddok/study/service/StudyRecruitmentQueryService.java
@@ -84,13 +84,10 @@ public class StudyRecruitmentQueryService {
 
         // 6) 주소(online → null), 선호연령(0/0 → null)
         LocationDto location = buildLocationForRead(study);
-        PreferredAgesDto ages =
-                (isZero(study.getAgeMin()) && isZero(study.getAgeMax()))
-                        ? null
-                        : PreferredAgesDto.builder()
-                        .ageMin(study.getAgeMin())
-                        .ageMax(study.getAgeMax())
-                        .build();
+        PreferredAgesDto ages = PreferredAgesDto.of(
+                study.getAgeMin(),
+                study.getAgeMax()
+        );
 
 
         boolean isApplied = false;

--- a/src/main/java/goorm/ddok/study/service/StudyRecruitmentService.java
+++ b/src/main/java/goorm/ddok/study/service/StudyRecruitmentService.java
@@ -156,7 +156,7 @@ public class StudyRecruitmentService {
                 .expectedMonth(study.getExpectedMonths())
                 .mode(study.getMode())
                 .location(location)
-                .preferredAges(PreferredAgesDto.builder().ageMin(study.getAgeMin()).ageMax(study.getAgeMax()).build())
+                .preferredAges(PreferredAgesDto.of(study.getAgeMin(), study.getAgeMax()))
                 .capacity(study.getCapacity())
                 .bannerImageUrl(study.getBannerImageUrl())
                 .traits(study.getTraits().stream().map(StudyRecruitmentTrait::getTraitName).toList())


### PR DESCRIPTION
## 🔀 PR 제목 
- [Fix] 지역명 표기 개선 (region1depthName/region2depthName 그대로 노출)

---

## 📌 작업 내용 요약
어떤 작업을 했는지 간략히 설명해주세요.

- ProjectLocationResponse, StudyLocationResponse에서 normalizeRegion1 제거
- 지역명이 잘리던 문제(강원 → 강원특별자치도, 서울 → 서울특별시) 수정
- 응답 DTO에서 region1depthName + region2depthName 그대로 노출하도록 변경
---

## ✅ 체크리스트
PR을 올리기 전에 아래 항목을 확인했나요?

- [x] 기능 요구사항을 모두 구현했나요?
- [x] 로컬에서 기능을 직접 테스트했나요?
- [x] 코드 컨벤션 및 스타일을 지켰나요?
- [x] 관련된 이슈에 연결했나요?

---

## 🔗 관련 이슈
`Closes #이슈번호` 또는 `Related to #이슈번호` 형태로 작성

- Related to #224 
---

## 📎 기타 참고 사항
추가로 리뷰어가 참고해야 할 사항이 있다면 적어주세요.

예시:
- API 명세 변경사항 포함됨
- 테스트 코드는 다음 PR에서 작성 예정
