### PR TITLE
fix(preferredAge): preferredAges 응답 변환 시 0 → null 처리 적용 DP-350

### DIFF
--- a/src/main/java/goorm/ddok/global/dto/PreferredAgesDto.java
+++ b/src/main/java/goorm/ddok/global/dto/PreferredAgesDto.java
@@ -18,10 +18,12 @@ public class PreferredAgesDto {
     private Integer ageMax;
 
     public static PreferredAgesDto of(Integer min, Integer max) {
-        if (min == null && max == null) return null;
+        Integer normalizedMin = (min == null || min == 0) ? null : min;
+        Integer normalizedMax = (max == null || max == 0) ? null : max;
+        if (normalizedMin == null && normalizedMax == null) return null;
         return PreferredAgesDto.builder()
-                .ageMin(min)
-                .ageMax(max)
+                .ageMin(normalizedMin)
+                .ageMax(normalizedMax)
                 .build();
     }
 }

--- a/src/main/java/goorm/ddok/project/service/ProjectRecruitmentEditService.java
+++ b/src/main/java/goorm/ddok/project/service/ProjectRecruitmentEditService.java
@@ -129,8 +129,8 @@ public class ProjectRecruitmentEditService {
                 .toList();
 
         PreferredAgesDto ages = PreferredAgesDto.of(
-                (pr.getAgeMin() == 0 ? null : pr.getAgeMin()),
-                (pr.getAgeMax() == 0 ? null : pr.getAgeMax())
+                (pr.getAgeMin() == null || pr.getAgeMin() == 0 ? null : pr.getAgeMin()),
+                (pr.getAgeMax() == null || pr.getAgeMax() == 0 ? null : pr.getAgeMax())
         );
 
         return ProjectDetailResponse.builder()
@@ -208,15 +208,16 @@ public class ProjectRecruitmentEditService {
         }
 
         // 연령 무관(null) 또는 10단위 강제
-        int ageMin;
-        int ageMax;
-        if (req.getPreferredAges() == null) {
-            ageMin = 0;
-            ageMax = 0;
-        } else {
+        Integer ageMin = null;
+        Integer ageMax = null;
+
+        if (req.getPreferredAges() != null) {
             ageMin = req.getPreferredAges().getAgeMin();
             ageMax = req.getPreferredAges().getAgeMax();
-            if (ageMin > ageMax) throw new GlobalException(ErrorCode.INVALID_AGE_RANGE);
+
+            if (ageMin > ageMax) {
+                throw new GlobalException(ErrorCode.INVALID_AGE_RANGE);
+            }
             if (ageMin % 10 != 0 || ageMax % 10 != 0) {
                 throw new GlobalException(ErrorCode.INVALID_AGE_BUCKET);
             }
@@ -452,8 +453,8 @@ public class ProjectRecruitmentEditService {
 
         // 무관(0/0)일 때 null
         PreferredAgesDto prefAges = PreferredAgesDto.of(
-                (pr.getAgeMin() == 0 ? null : pr.getAgeMin()),
-                (pr.getAgeMax() == 0 ? null : pr.getAgeMax())
+                (pr.getAgeMin() == null || pr.getAgeMin() == 0 ? null : pr.getAgeMin()),
+                (pr.getAgeMax() == null || pr.getAgeMax() == 0 ? null : pr.getAgeMax())
         );
 
         // 리더/참여자 조회


### PR DESCRIPTION
## 🔀 PR 제목
- [Fix] preferredAges 응답 0 값 null 변환 처리

---

## 📌 작업 내용 요약
어떤 작업을 했는지 간략히 설명해주세요.

- PreferredAgesDto.of() 에서 ageMin/ageMax 가 0일 경우 null 로 변환되도록 수정
- 불필요하게 "preferredAges": { "ageMin": 0, "ageMax": 0 } 가 내려가는 문제 해결

---

## ✅ 체크리스트
PR을 올리기 전에 아래 항목을 확인했나요?

- [x] 기능 요구사항을 모두 구현했나요?
- [x] 로컬에서 기능을 직접 테스트했나요?
- [x] 코드 컨벤션 및 스타일을 지켰나요?
- [x] 관련된 이슈에 연결했나요?

---

## 🔗 관련 이슈
`Closes #이슈번호` 또는 `Related to #이슈번호` 형태로 작성

예시:
- Closes #이슈번호
- Related to #이슈번호
---

## 📎 기타 참고 사항
추가로 리뷰어가 참고해야 할 사항이 있다면 적어주세요.

예시:
- API 명세 변경사항 포함됨
- 테스트 코드는 다음 PR에서 작성 예정
